### PR TITLE
Add deployment pipeline

### DIFF
--- a/cloudbuild.master.yaml
+++ b/cloudbuild.master.yaml
@@ -6,4 +6,4 @@ steps:
   - name: "haskell"
     args: [ "cabal", "run", "site", "build" ]
   - name: "gcr.io/cloud-builders/gsutil"
-    args: [ "-m", "rsync", "-r", "-d", "_site/", "gs://d.blog.alunduil.com/" ]
+    args: [ "-m", "rsync", "-r", "-d", "_site/", "gs://blog.alunduil.com/" ]

--- a/cloudbuild.master.yaml
+++ b/cloudbuild.master.yaml
@@ -2,6 +2,8 @@ steps:
   - name: "haskell"
     args: [ "cabal", "sandbox", "init" ]
   - name: "haskell"
+    args: [ "cabal", "install", "--only-dependencies", "--force-reinstalls", "--ghc-options=-O0", "--reorder-goals", "--max-backjumps=-1" ]
+  - name: "haskell"
     args: [ "cabal", "configure", "--ghc-options", "\"-O0 -Werror\"" ]
   - name: "haskell"
     args: [ "cabal", "run", "site", "build" ]

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -6,4 +6,4 @@ steps:
   - name: "haskell"
     args: [ "cabal", "run", "site", "build" ]
   - name: "gcr.io/cloud-builders/gsutil"
-    args: [ "-m", "rsync", "-r", "-d", "_site/", "gs://d.blog.alunduil.com/" ]
+    args: [ "-m", "rsync", "-r", "-d", "_site/", "gs://r.blog.alunduil.com/" ]

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -2,6 +2,8 @@ steps:
   - name: "haskell"
     args: [ "cabal", "sandbox", "init" ]
   - name: "haskell"
+    args: [ "cabal", "install", "--only-dependencies", "--force-reinstalls", "--ghc-options=-O0", "--reorder-goals", "--max-backjumps=-1" ]
+  - name: "haskell"
     args: [ "cabal", "configure", "--ghc-options", "\"-O0 -Werror\"" ]
   - name: "haskell"
     args: [ "cabal", "run", "site", "build" ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,8 @@ steps:
   - name: "haskell"
     args: [ "cabal", "sandbox", "init" ]
   - name: "haskell"
+    args: [ "cabal", "install", "--only-dependencies", "--force-reinstalls", "--ghc-options=-O0", "--reorder-goals", "--max-backjumps=-1" ]
+  - name: "haskell"
     args: [ "cabal", "configure", "--ghc-options", "\"-O0 -Werror\"" ]
   - name: "haskell"
     args: [ "cabal", "run", "site", "build" ]


### PR DESCRIPTION
Adding several cloudbuild configuration files so we can push to developer preview and release candidate buckets as well.  This will improve the ability to verify things are correct before publishing to the main blog.