### PR TITLE
Add /digest skill with shell + bats verification

### DIFF
--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -5,17 +5,17 @@ description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise h
 
 # Digest
 
-## Flow
+Pipeline: **collect → analyze data → synthesize themes → analyze themes → present**. Each stage has a different owner; don't smear them.
 
-### 1. Collect GitHub data via the script
+## 1. Collect (script)
 
 ```bash
 bash .claude/skills/digest/collect.sh "$cadence"
 ```
 
-The script owns cadence parsing, `last-run` reads, the `gh` query fan-out, and heuristic filters (squash-merge dupes, `alunduil/alunduil-claustre-state` sync noise, `task/*` + `release-please--*` agent branches, URL→repo parsing, events-window-too-wide). It exits non-zero with a stderr message on invalid cadence.
+The script owns cadence parsing, `last-run` reads, the `gh` query fan-out, heuristic noise filters (squash-merge dupes, `alunduil/alunduil-claustre-state` sync noise, `task/*` + `release-please--*` agent branches), URL→repo parsing, truncation detection, and the per-repo rollup. Exits non-zero with a stderr message on invalid cadence.
 
-Capture stdout and parse as JSON:
+JSON shape:
 
 ```json
 {
@@ -24,39 +24,61 @@ Capture stdout and parse as JSON:
     "events_included": true,
     "limit": 300, "truncated": ["issues_opened", ...]
   },
+  "repos": {
+    "owner/repo": {
+      "commits": N, "prs_opened": N, "prs_reviewed": N,
+      "issues_opened": N, "issues_closed": N, "commented": N,
+      "days_active": ["YYYY-MM-DD", ...]
+    }
+  },
   "commits": [...], "prs_opened": [...], "prs_reviewed": [...],
   "issues_opened": [...], "issues_closed": [...],
   "commented": [...], "events": [...]
 }
 ```
 
-**If `window.truncated` is non-empty**, surface it in the digest output above the themed clusters: "⚠️ Truncated at limit (300): `<source>`. Narrow the window or raise `LIMIT` if completeness matters this week." The `commits` source often appears here even on light weeks because many raw commits are squash-merge dupes the filter strips — note this if commits is the only entry, since the items you'd be missing are likely also noise.
+## 2. Analyze data (Claude pre-synthesis)
 
-### 2. Fetch Readwise + Reader for the same window via MCP
-
-Use `window.since` (append `T00:00:00Z` for ISO-8601):
+Fetch Readwise + Reader for the same window via MCP, using `window.since` (append `T00:00:00Z`):
 
 - `readwise_list_highlights` — `highlighted_at_gt=<since>T00:00:00Z`, `page_size=100`, `response_fields=["text","note","url","highlighted_at","book_title","book_author"]`.
-- `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = read-with-intent.
+- `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = engaged-with.
 
-If MCP tools are unavailable on this machine, note "Readwise/Reader unavailable — GitHub-only digest" and continue.
+If MCP unavailable, note "Readwise/Reader unavailable — GitHub-only digest" and continue.
 
-Cross-reference: for each archived doc, set `has_highlights = true` if any highlight's `url` matches the doc's `url`. Use as a soft signal in synthesis (highlighted reads weight higher than skim-and-archive).
+Mechanical patterns to extract before synthesis:
 
-### 3. Cluster thematically across all sources
+- **Cross-source links**: archived Reader docs whose `url` matches a Readwise highlight → tag `has_highlights = true`. A highlight is a stronger engagement signal than archive alone.
+- **Completion arcs**: issues that appear in both `issues_opened` and `issues_closed` within the window. Narrative-ready ("started and finished this week").
+- **Cross-project signals**: use `repos[].days_active` to spot repos with simultaneous activity bursts. Same kind of work hitting multiple repos on the same days is often a single underlying decision worth surfacing.
+- **Truncation**: if `window.truncated` is non-empty (excluding `commits`-only — squash-dedup destroys most raw items so commits-only truncation is usually noise), surface as a warning above the themed clusters.
 
-Pick **4–8 themes** that might seed a blog post. Don't enumerate everything. Each theme:
+## 3. Synthesize themes (Claude)
 
-- 1–2 sentence summary of what's interesting.
-- Bullet list of supporting items (link + terse identifier).
-- Order items by engagement weight: direct-to-trunk commits > merged PRs > comments; highlighted Reader docs > unhighlighted articles > RSS items.
-- If a single theme's tail exceeds ~10 items, collapse with `+N more — see <gh query | url>`.
+Cluster items across all sources into **4–8 themes** that might seed a blog post. Don't enumerate everything. Each theme:
 
-### 4. Print the themed digest to chat
+- 1–2 sentence summary of what makes it interesting.
+- Bullet list of supporting items (link + terse identifier), ordered **neutrally** — date desc within the theme. **No engagement weighting at this layer.**
+- If a theme's tail exceeds ~10 items, collapse with `+N more — see <gh query | url>`.
 
-End with an empty `## Idea kernels` section.
+Direct-to-trunk commits and merged PRs are equivalent for clustering and ranking — pair-heavy repos use direct writes interchangeably with PRs.
 
-### 5. Wait for a positive-value signal before writing `last-run`
+## 4. Analyze themes (Claude)
+
+Score each theme by signal-of-engagement-with-the-topic, present themes in descending score. Engagement is at the topic layer, not the item layer:
+
+- **Source breadth**: how many of {commits, PRs, issues_opened, issues_closed, comments, highlights, archives} contribute. Theme spanning 4+ sources beats theme drawn from one.
+- **Cross-source resonance**: theme has both a GitHub item AND a Readwise highlight on the same topic. External validation. Heavy weight.
+- **Completion arc presence**: theme contains an opened+closed issue or merged PR-with-explicit-Closes. Narrative-ready, easier to write.
+- **Time span**: spans the whole window > single-day burst (sustained interest > momentary distraction).
+- **Cross-project**: same theme across multiple repos = pattern at a higher altitude, often the post-worthy angle.
+- **Volume**: tiebreaker only. More items ≠ inherently more interesting.
+
+## 5. Present + wait
+
+Print the themed digest to chat. Truncation warning (if any) above clusters. End with empty `## Idea kernels` section.
+
+Wait for a positive-value signal before writing `last-run`:
 
 - "no kernels here" / "nothing of interest" → write `window.now` to `.claude/skills/digest/last-run`.
 - "file idea X" (one or many) → file each via `gh issue create --template idea --label idea --title "<outcome>"`, pass `--body` directly with Spark / Why interesting / Open questions / Source material filled from conversation. Then write `last-run`.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -19,12 +19,18 @@ Capture stdout and parse as JSON:
 
 ```json
 {
-  "window": {"since": "YYYY-MM-DD", "now": "ISO-8601-UTC", "events_included": true},
+  "window": {
+    "since": "YYYY-MM-DD", "now": "ISO-8601-UTC",
+    "events_included": true,
+    "limit": 300, "truncated": ["issues_opened", ...]
+  },
   "commits": [...], "prs_opened": [...], "prs_reviewed": [...],
   "issues_opened": [...], "issues_closed": [...],
   "commented": [...], "events": [...]
 }
 ```
+
+**If `window.truncated` is non-empty**, surface it in the digest output above the themed clusters: "⚠️ Truncated at limit (300): `<source>`. Narrow the window or raise `LIMIT` if completeness matters this week." The `commits` source often appears here even on light weeks because many raw commits are squash-merge dupes the filter strips — note this if commits is the only entry, since the items you'd be missing are likely also noise.
 
 ### 2. Fetch Readwise + Reader for the same window via MCP
 

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: digest
+description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, and Reader archives — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`) or `last` (default — reads `.claude/skills/digest/last-run`, falls back to `1w` with a warning if absent). Output is chat-only, thematically clustered. Promising kernels → `gh issue create --template idea`.
+---
+
+# Digest
+
+## Flow
+
+### 1. Collect GitHub data via the script
+
+```bash
+bash .claude/skills/digest/collect.sh "$cadence"
+```
+
+The script owns cadence parsing, `last-run` reads, the `gh` query fan-out, and heuristic filters (squash-merge dupes, `alunduil/alunduil-claustre-state` sync noise, `task/*` + `release-please--*` agent branches, URL→repo parsing, events-window-too-wide). It exits non-zero with a stderr message on invalid cadence.
+
+Capture stdout and parse as JSON:
+
+```json
+{
+  "window": {"since": "YYYY-MM-DD", "now": "ISO-8601-UTC", "events_included": true},
+  "commits": [...], "prs_opened": [...], "prs_reviewed": [...],
+  "issues_opened": [...], "commented": [...], "events": [...]
+}
+```
+
+### 2. Fetch Readwise + Reader for the same window via MCP
+
+Use `window.since` (append `T00:00:00Z` for ISO-8601):
+
+- `readwise_list_highlights` — `highlighted_at_gt=<since>T00:00:00Z`, `page_size=100`, `response_fields=["text","note","url","highlighted_at","book_title","book_author"]`.
+- `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = read-with-intent.
+
+If MCP tools are unavailable on this machine, note "Readwise/Reader unavailable — GitHub-only digest" and continue.
+
+Cross-reference: for each archived doc, set `has_highlights = true` if any highlight's `url` matches the doc's `url`. Use as a soft signal in synthesis (highlighted reads weight higher than skim-and-archive).
+
+### 3. Cluster thematically across all sources
+
+Pick **4–8 themes** that might seed a blog post. Don't enumerate everything. Each theme:
+
+- 1–2 sentence summary of what's interesting.
+- Bullet list of supporting items (link + terse identifier).
+- Order items by engagement weight: direct-to-trunk commits > merged PRs > comments; highlighted Reader docs > unhighlighted articles > RSS items.
+- If a single theme's tail exceeds ~10 items, collapse with `+N more — see <gh query | url>`.
+
+### 4. Print the themed digest to chat
+
+End with an empty `## Idea kernels` section.
+
+### 5. Wait for a positive-value signal before writing `last-run`
+
+- "no kernels here" / "nothing of interest" → write `window.now` to `.claude/skills/digest/last-run`.
+- "file idea X" (one or many) → file each via `gh issue create --template idea --label idea --title "<outcome>"`, pass `--body` directly with Spark / Why interesting / Open questions / Source material filled from conversation. Then write `last-run`.
+- Anything else (silence, "let me think", "re-run") → don't write.
+
+After writing, end with one line: `last-run updated to <now> — git add/commit when ready.`
+
+`last-run` is tracked so a fresh checkout or worktree shares it.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -21,7 +21,8 @@ Capture stdout and parse as JSON:
 {
   "window": {"since": "YYYY-MM-DD", "now": "ISO-8601-UTC", "events_included": true},
   "commits": [...], "prs_opened": [...], "prs_reviewed": [...],
-  "issues_opened": [...], "commented": [...], "events": [...]
+  "issues_opened": [...], "issues_closed": [...],
+  "commented": [...], "events": [...]
 }
 ```
 

--- a/.claude/skills/digest/collect.bats
+++ b/.claude/skills/digest/collect.bats
@@ -181,3 +181,26 @@ teardown() {
   [ "$(jq -r '.[0].repo' <<<"$result")" = "owner/repo" ]
   [ "$(jq -r '.[0].closedAt' <<<"$result")" = "2026-04-30T12:00:00Z" ]
 }
+
+# --- truncation detection ---
+
+@test "detect_truncated lists keys whose count saturated the limit" {
+  source "$SCRIPT"
+  input='{"commits":300,"prs_opened":50,"issues_opened":300,"issues_closed":42}'
+  result=$(echo "$input" | detect_truncated)
+  [ "$(jq 'length' <<<"$result")" -eq 2 ]
+  [ "$(jq -r '.[0]' <<<"$result")" = "commits" ]
+  [ "$(jq -r '.[1]' <<<"$result")" = "issues_opened" ]
+}
+
+@test "detect_truncated returns empty array when nothing saturated" {
+  source "$SCRIPT"
+  result=$(echo '{"commits":9,"prs_opened":83,"issues_opened":100}' | detect_truncated)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "detect_truncated treats counts above the limit as truncated too" {
+  source "$SCRIPT"
+  result=$(echo '{"commits":350}' | detect_truncated)
+  [ "$(jq -r '.[0]' <<<"$result")" = "commits" ]
+}

--- a/.claude/skills/digest/collect.bats
+++ b/.claude/skills/digest/collect.bats
@@ -174,3 +174,10 @@ teardown() {
   result=$(echo '[{"number":7,"title":"x","state":"open","url":"https://github.com/owner/repo/issues/7","createdAt":"2026-04-26T00:00:00Z"}]' | filter_issues_opened)
   [ "$(jq -r '.[0].repo' <<<"$result")" = "owner/repo" ]
 }
+
+@test "filter_issues_closed projects closedAt and parses repo from URL" {
+  source "$SCRIPT"
+  result=$(echo '[{"number":7,"title":"x","state":"closed","url":"https://github.com/owner/repo/issues/7","closedAt":"2026-04-30T12:00:00Z"}]' | filter_issues_closed)
+  [ "$(jq -r '.[0].repo' <<<"$result")" = "owner/repo" ]
+  [ "$(jq -r '.[0].closedAt' <<<"$result")" = "2026-04-30T12:00:00Z" ]
+}

--- a/.claude/skills/digest/collect.bats
+++ b/.claude/skills/digest/collect.bats
@@ -204,3 +204,67 @@ teardown() {
   result=$(echo '{"commits":350}' | detect_truncated)
   [ "$(jq -r '.[0]' <<<"$result")" = "commits" ]
 }
+
+# --- per-repo rollup ---
+
+@test "rollup_repos returns empty object on empty input" {
+  source "$SCRIPT"
+  result=$(echo '{"commits":[],"prs_opened":[],"prs_reviewed":[],"issues_opened":[],"issues_closed":[],"commented":[]}' | rollup_repos)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "rollup_repos counts a single commit and records day_active" {
+  source "$SCRIPT"
+  input='{"commits":[{"repo":"a/b","sha":"abc1234","subject":"x","date":"2026-04-27T22:00:00Z"}],"prs_opened":[],"prs_reviewed":[],"issues_opened":[],"issues_closed":[],"commented":[]}'
+  result=$(echo "$input" | rollup_repos)
+  [ "$(jq -r '."a/b".commits' <<<"$result")" = "1" ]
+  [ "$(jq -r '."a/b".days_active[0]' <<<"$result")" = "2026-04-27" ]
+}
+
+@test "rollup_repos sums across sources and unions days for one repo" {
+  source "$SCRIPT"
+  input='{
+    "commits":[{"repo":"a/b","sha":"x","subject":"y","date":"2026-04-27T10:00:00Z"}],
+    "prs_opened":[{"repo":"a/b","n":1,"title":"x","state":"open","url":"https://github.com/a/b/pull/1","createdAt":"2026-04-28T10:00:00Z"}],
+    "prs_reviewed":[],
+    "issues_opened":[{"repo":"a/b","n":2,"title":"x","state":"open","url":"https://github.com/a/b/issues/2","createdAt":"2026-04-27T11:00:00Z"}],
+    "issues_closed":[],
+    "commented":[]
+  }'
+  result=$(echo "$input" | rollup_repos)
+  [ "$(jq -r '."a/b".commits' <<<"$result")" = "1" ]
+  [ "$(jq -r '."a/b".prs_opened' <<<"$result")" = "1" ]
+  [ "$(jq -r '."a/b".issues_opened' <<<"$result")" = "1" ]
+  # Same-day items collapse; days_active sorted ascending.
+  [ "$(jq -r '."a/b".days_active | length' <<<"$result")" -eq 2 ]
+  [ "$(jq -r '."a/b".days_active[0]' <<<"$result")" = "2026-04-27" ]
+  [ "$(jq -r '."a/b".days_active[1]' <<<"$result")" = "2026-04-28" ]
+}
+
+@test "rollup_repos splits across multiple repos" {
+  source "$SCRIPT"
+  input='{
+    "commits":[
+      {"repo":"a/b","sha":"x","subject":"y","date":"2026-04-27T10:00:00Z"},
+      {"repo":"c/d","sha":"x","subject":"y","date":"2026-04-30T10:00:00Z"}
+    ],
+    "prs_opened":[],"prs_reviewed":[],"issues_opened":[],"issues_closed":[],"commented":[]
+  }'
+  result=$(echo "$input" | rollup_repos)
+  [ "$(jq 'length' <<<"$result")" -eq 2 ]
+  [ "$(jq -r '."a/b".commits' <<<"$result")" = "1" ]
+  [ "$(jq -r '."c/d".commits' <<<"$result")" = "1" ]
+}
+
+@test "rollup_repos drops items missing repo or date" {
+  source "$SCRIPT"
+  input='{
+    "commits":[
+      {"repo":null,"sha":"x","subject":"y","date":"2026-04-27T10:00:00Z"},
+      {"repo":"a/b","sha":"x","subject":"y","date":null}
+    ],
+    "prs_opened":[],"prs_reviewed":[],"issues_opened":[],"issues_closed":[],"commented":[]
+  }'
+  result=$(echo "$input" | rollup_repos)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}

--- a/.claude/skills/digest/collect.bats
+++ b/.claude/skills/digest/collect.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+# shellcheck disable=SC1090  # SCRIPT is dynamic; sourcing the unit under test is the pattern
+bats_require_minimum_version 1.5.0
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/collect.sh"
+  TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TMP_DIR"
+}
+
+# --- Cadence grammar ---
+
+@test "valid cadence: 7d resolves" {
+  source "$SCRIPT"
+  run resolve_since 7d
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+}
+
+@test "valid cadence: 4w resolves" {
+  source "$SCRIPT"
+  run resolve_since 4w
+  [ "$status" -eq 0 ]
+}
+
+@test "valid cadence: 6m resolves" {
+  source "$SCRIPT"
+  run resolve_since 6m
+  [ "$status" -eq 0 ]
+}
+
+@test "valid cadence: 1y resolves" {
+  source "$SCRIPT"
+  run resolve_since 1y
+  [ "$status" -eq 0 ]
+}
+
+@test "invalid cadence: foo rejected with grammar message" {
+  source "$SCRIPT"
+  run resolve_since foo
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"invalid cadence"* ]]
+  [[ "$output" == *"Nd | Nw | Nm | Ny"* ]]
+}
+
+@test "invalid cadence: empty string rejected" {
+  source "$SCRIPT"
+  run resolve_since ""
+  [ "$status" -eq 2 ]
+}
+
+@test "invalid cadence: 0d rejected (must be 1+)" {
+  source "$SCRIPT"
+  run resolve_since 0d
+  [ "$status" -eq 2 ]
+}
+
+@test "invalid cadence: 7days rejected" {
+  source "$SCRIPT"
+  run resolve_since 7days
+  [ "$status" -eq 2 ]
+}
+
+# --- last-run fallback ---
+
+@test "last with empty state file warns and falls back to 1w" {
+  source "$SCRIPT"
+  LAST_RUN_FILE="$TMP_DIR/last-run"
+  : >"$LAST_RUN_FILE"
+
+  run --separate-stderr resolve_since last
+  [ "$status" -eq 0 ]
+  [[ "$stderr" == *"falling back to 1w"* ]]
+  expected=$(date -d "1 week ago" -u +%Y-%m-%d)
+  [ "$output" = "$expected" ]
+}
+
+@test "last with date in state file uses that date" {
+  source "$SCRIPT"
+  LAST_RUN_FILE="$TMP_DIR/last-run"
+  echo "2026-01-15T00:00:00Z" >"$LAST_RUN_FILE"
+
+  run resolve_since last
+  [ "$status" -eq 0 ]
+  [ "$output" = "2026-01-15" ]
+}
+
+# --- filter_commits heuristics ---
+
+@test "filter_commits drops squash-merge PR subject" {
+  source "$SCRIPT"
+  result=$(echo '[{"repository":{"fullName":"a/b"},"sha":"abc1234","commit":{"message":"feat: thing (#42)","author":{"date":"2026-04-26T00:00:00Z"}}}]' | filter_commits)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "filter_commits keeps direct-to-trunk commit (no PR suffix)" {
+  source "$SCRIPT"
+  result=$(echo '[{"repository":{"fullName":"a/b"},"sha":"abc1234","commit":{"message":"direct work on trunk","author":{"date":"2026-04-26T00:00:00Z"}}}]' | filter_commits)
+  [ "$(jq 'length' <<<"$result")" -eq 1 ]
+}
+
+@test "filter_commits drops commits in sync-noise repo" {
+  source "$SCRIPT"
+  result=$(echo '[{"repository":{"fullName":"alunduil/alunduil-claustre-state"},"sha":"abc1234","commit":{"message":"anything","author":{"date":"2026-04-26T00:00:00Z"}}}]' | filter_commits)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "filter_commits drops sync: subject prefix" {
+  source "$SCRIPT"
+  result=$(echo '[{"repository":{"fullName":"a/b"},"sha":"abc1234","commit":{"message":"sync: penguin at 2026-04-27","author":{"date":"2026-04-26T00:00:00Z"}}}]' | filter_commits)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "filter_commits projects subject (first line of message only)" {
+  source "$SCRIPT"
+  # JSON \n is interpreted by jq as a real newline, so split("\n") works.
+  result=$(printf '%s' '[{"repository":{"fullName":"a/b"},"sha":"abc1234567","commit":{"message":"subject line\n\nbody paragraph that should be dropped","author":{"date":"2026-04-26T00:00:00Z"}}}]' | filter_commits)
+  [ "$(jq -r '.[0].subject' <<<"$result")" = "subject line" ]
+  [ "$(jq -r '.[0].sha' <<<"$result")" = "abc1234" ]
+}
+
+# --- filter_events heuristics ---
+
+@test "filter_events drops task/* CreateEvent" {
+  source "$SCRIPT"
+  result=$(echo '[{"type":"CreateEvent","created_at":"2026-04-30T00:00:00Z","repo":{"name":"a/b"},"payload":{"ref":"task/work-on-something","ref_type":"branch"}}]' | filter_events 2026-04-26)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "filter_events drops release-please-- CreateEvent" {
+  source "$SCRIPT"
+  result=$(echo '[{"type":"CreateEvent","created_at":"2026-04-30T00:00:00Z","repo":{"name":"a/b"},"payload":{"ref":"release-please--branches--main","ref_type":"branch"}}]' | filter_events 2026-04-26)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "filter_events keeps non-task branch CreateEvent" {
+  source "$SCRIPT"
+  result=$(echo '[{"type":"CreateEvent","created_at":"2026-04-30T00:00:00Z","repo":{"name":"a/b"},"payload":{"ref":"main","ref_type":"branch"}}]' | filter_events 2026-04-26)
+  [ "$(jq 'length' <<<"$result")" -eq 1 ]
+}
+
+@test "filter_events keeps WatchEvent (star)" {
+  source "$SCRIPT"
+  result=$(echo '[{"type":"WatchEvent","created_at":"2026-04-30T00:00:00Z","repo":{"name":"a/b"},"payload":{}}]' | filter_events 2026-04-26)
+  [ "$(jq 'length' <<<"$result")" -eq 1 ]
+}
+
+@test "filter_events excludes events before SINCE" {
+  source "$SCRIPT"
+  result=$(echo '[{"type":"WatchEvent","created_at":"2026-04-20T00:00:00Z","repo":{"name":"a/b"},"payload":{}}]' | filter_events 2026-04-26)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+@test "filter_events drops event types already covered by search (e.g. PushEvent)" {
+  source "$SCRIPT"
+  result=$(echo '[{"type":"PushEvent","created_at":"2026-04-30T00:00:00Z","repo":{"name":"a/b"},"payload":{}}]' | filter_events 2026-04-26)
+  [ "$(jq 'length' <<<"$result")" -eq 0 ]
+}
+
+# --- URL → repo parsing ---
+
+@test "filter_prs_opened parses repo from URL" {
+  source "$SCRIPT"
+  result=$(echo '[{"number":42,"title":"x","state":"open","url":"https://github.com/owner/repo/pull/42","createdAt":"2026-04-26T00:00:00Z"}]' | filter_prs_opened)
+  [ "$(jq -r '.[0].repo' <<<"$result")" = "owner/repo" ]
+}
+
+@test "filter_issues_opened parses repo from URL" {
+  source "$SCRIPT"
+  result=$(echo '[{"number":7,"title":"x","state":"open","url":"https://github.com/owner/repo/issues/7","createdAt":"2026-04-26T00:00:00Z"}]' | filter_issues_opened)
+  [ "$(jq -r '.[0].repo' <<<"$result")" = "owner/repo" ]
+}

--- a/.claude/skills/digest/collect.sh
+++ b/.claude/skills/digest/collect.sh
@@ -104,47 +104,21 @@ package() {
     '{raw_count: $n, items: $i}'
 }
 
-fetch_commits() {
+# Generic search wrapper: gh_search SUBCMD QUAL DATE_FLAG SINCE FIELDS FILTER_FN
+gh_search() {
+  local subcmd=$1 qual=$2 date_flag=$3 since=$4 fields=$5 filter_fn=$6
   local raw
-  raw=$(gh search commits --author=@me --author-date=">$1" --limit "$LIMIT" \
-    --json repository,sha,commit 2>/dev/null)
-  package "$raw" "$(filter_commits <<<"$raw")"
+  raw=$(gh search "$subcmd" "$qual=@me" "$date_flag=>$since" \
+    --limit "$LIMIT" --json "$fields" 2>/dev/null)
+  package "$raw" "$("$filter_fn" <<<"$raw")"
 }
 
-fetch_prs_opened() {
-  local raw
-  raw=$(gh search prs --author=@me --created=">$1" --limit "$LIMIT" \
-    --json number,title,state,url,createdAt 2>/dev/null)
-  package "$raw" "$(filter_prs_opened <<<"$raw")"
-}
-
-fetch_prs_reviewed() {
-  local raw
-  raw=$(gh search prs --reviewed-by=@me --updated=">$1" --limit "$LIMIT" \
-    --json number,title,url,author,updatedAt 2>/dev/null)
-  package "$raw" "$(filter_prs_reviewed <<<"$raw")"
-}
-
-fetch_issues_opened() {
-  local raw
-  raw=$(gh search issues --author=@me --created=">$1" --limit "$LIMIT" \
-    --json number,title,state,url,createdAt 2>/dev/null)
-  package "$raw" "$(filter_issues_opened <<<"$raw")"
-}
-
-fetch_issues_closed() {
-  local raw
-  raw=$(gh search issues --author=@me --closed=">$1" --limit "$LIMIT" \
-    --json number,title,state,url,closedAt 2>/dev/null)
-  package "$raw" "$(filter_issues_closed <<<"$raw")"
-}
-
-fetch_commented() {
-  local raw
-  raw=$(gh search issues --commenter=@me --updated=">$1" --limit "$LIMIT" \
-    --json number,title,url,updatedAt 2>/dev/null)
-  package "$raw" "$(filter_commented <<<"$raw")"
-}
+fetch_commits()       { gh_search commits --author      --author-date "$1" repository,sha,commit             filter_commits; }
+fetch_prs_opened()    { gh_search prs     --author      --created     "$1" number,title,state,url,createdAt  filter_prs_opened; }
+fetch_prs_reviewed()  { gh_search prs     --reviewed-by --updated     "$1" number,title,url,author,updatedAt filter_prs_reviewed; }
+fetch_issues_opened() { gh_search issues  --author      --created     "$1" number,title,state,url,createdAt  filter_issues_opened; }
+fetch_issues_closed() { gh_search issues  --author      --closed      "$1" number,title,state,url,closedAt   filter_issues_closed; }
+fetch_commented()     { gh_search issues  --commenter   --updated     "$1" number,title,url,updatedAt        filter_commented; }
 
 # Reads {name: raw_count, ...} on stdin, emits sorted array of names
 # whose count saturated the limit.

--- a/.claude/skills/digest/collect.sh
+++ b/.claude/skills/digest/collect.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# /digest data collector. Fans out GitHub queries, applies heuristic
+# filters, and emits structured JSON to stdout.
+#
+# Usage: collect.sh [cadence]
+# Cadence: last (default) | Nd | Nw | Nm | Ny
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+LAST_RUN_FILE="$SCRIPT_DIR/last-run"
+LOGIN=alunduil
+
+SQUASH_MERGE_RE=' \(#[0-9]+\)$'
+SYNC_NOISE_REPO='alunduil/alunduil-claustre-state'
+SYNC_NOISE_SUBJECT_RE='^sync: '
+NOISE_REF_RE='^(task/|release-please--)'
+INTEREST_EVENT_TYPES=(WatchEvent ForkEvent CreateEvent ReleaseEvent PublicEvent MemberEvent GollumEvent)
+
+# Extracts owner/repo from a github.com URL by positional split.
+REPO_FROM_URL='(.url | split("/") | .[3] + "/" + .[4])'
+
+resolve_since() {
+  local cadence="$1"
+  case "$cadence" in
+    last)
+      if [[ -s "$LAST_RUN_FILE" ]]; then
+        date -d "$(head -n 1 "$LAST_RUN_FILE")" -u +%Y-%m-%d
+      else
+        echo "warn: $LAST_RUN_FILE empty; falling back to 1w" >&2
+        date -d "1 week ago" -u +%Y-%m-%d
+      fi
+      ;;
+    [1-9]*[0-9]*d | [1-9]d) date -d "${cadence%d} days ago" -u +%Y-%m-%d ;;
+    [1-9]*[0-9]*w | [1-9]w) date -d "${cadence%w} weeks ago" -u +%Y-%m-%d ;;
+    [1-9]*[0-9]*m | [1-9]m) date -d "${cadence%m} months ago" -u +%Y-%m-%d ;;
+    [1-9]*[0-9]*y | [1-9]y) date -d "${cadence%y} years ago" -u +%Y-%m-%d ;;
+    *)
+      echo "error: invalid cadence '$cadence'. Expected: last | Nd | Nw | Nm | Ny" >&2
+      return 2
+      ;;
+  esac
+}
+
+filter_commits() {
+  jq --arg sync_repo "$SYNC_NOISE_REPO" \
+    --arg sync_re "$SYNC_NOISE_SUBJECT_RE" \
+    --arg squash_re "$SQUASH_MERGE_RE" \
+    '[.[]
+     | {repo: .repository.fullName,
+        sha: .sha[:7],
+        subject: (.commit.message | split("\n")[0]),
+        date: .commit.author.date}
+     | select(.subject | test($squash_re) | not)
+     | select(.subject | test($sync_re) | not)
+     | select(.repo != $sync_repo)
+    ]'
+}
+
+filter_prs_opened() {
+  jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, state, url, createdAt}]"
+}
+
+filter_prs_reviewed() {
+  jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, url, author: .author.login, updatedAt}]"
+}
+
+filter_issues_opened() {
+  jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, state, url, createdAt}]"
+}
+
+filter_commented() {
+  jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, url, updatedAt}]"
+}
+
+filter_events() {
+  local since="$1"
+  local types_json
+  types_json=$(printf '%s\n' "${INTEREST_EVENT_TYPES[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')
+  jq --argjson types "$types_json" \
+    --arg ref_re "$NOISE_REF_RE" \
+    --arg since "$since" \
+    '[.[]
+     | select(.created_at >= $since)
+     | select(.type as $t | $types | index($t))
+     | select((.type != "CreateEvent") or (.payload.ref | test($ref_re) | not))
+     | {type, repo: .repo.name, created_at, payload}
+    ]'
+}
+
+fetch_commits() {
+  gh search commits --author=@me --author-date=">$1" --limit 100 \
+    --json repository,sha,commit 2>/dev/null | filter_commits
+}
+
+fetch_prs_opened() {
+  gh search prs --author=@me --created=">$1" --limit 100 \
+    --json number,title,state,url,createdAt 2>/dev/null | filter_prs_opened
+}
+
+fetch_prs_reviewed() {
+  gh search prs --reviewed-by=@me --updated=">$1" --limit 100 \
+    --json number,title,url,author,updatedAt 2>/dev/null | filter_prs_reviewed
+}
+
+fetch_issues_opened() {
+  gh search issues --author=@me --created=">$1" --limit 100 \
+    --json number,title,state,url,createdAt 2>/dev/null | filter_issues_opened
+}
+
+fetch_commented() {
+  gh search issues --commenter=@me --updated=">$1" --limit 100 \
+    --json number,title,url,updatedAt 2>/dev/null | filter_commented
+}
+
+fetch_events() {
+  local since="$1" include="$2"
+  if [[ "$include" != "true" ]]; then
+    echo '[]'
+    return
+  fi
+  gh api "users/$LOGIN/events?per_page=100" --paginate 2>/dev/null |
+    jq -s 'add // []' | filter_events "$since"
+}
+
+main() {
+  local cadence="${1:-last}"
+  local since now since_epoch now_epoch days include_events
+  since=$(resolve_since "$cadence")
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  since_epoch=$(date -d "$since" -u +%s)
+  now_epoch=$(date -u +%s)
+  days=$(((now_epoch - since_epoch) / 86400))
+  include_events=true
+  if ((days > 90)); then
+    include_events=false
+  fi
+
+  jq -n \
+    --arg since "$since" \
+    --arg now "$now" \
+    --argjson include_events "$include_events" \
+    --argjson commits "$(fetch_commits "$since")" \
+    --argjson prs_opened "$(fetch_prs_opened "$since")" \
+    --argjson prs_reviewed "$(fetch_prs_reviewed "$since")" \
+    --argjson issues_opened "$(fetch_issues_opened "$since")" \
+    --argjson commented "$(fetch_commented "$since")" \
+    --argjson events "$(fetch_events "$since" "$include_events")" \
+    '{window: {since: $since, now: $now, events_included: $include_events},
+      commits: $commits,
+      prs_opened: $prs_opened,
+      prs_reviewed: $prs_reviewed,
+      issues_opened: $issues_opened,
+      commented: $commented,
+      events: $events}'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.claude/skills/digest/collect.sh
+++ b/.claude/skills/digest/collect.sh
@@ -153,6 +153,46 @@ detect_truncated() {
     '[to_entries[] | select(.value >= $limit) | .key] | sort'
 }
 
+# Reads {commits, prs_opened, prs_reviewed, issues_opened, issues_closed,
+# commented} mapped to filtered item arrays on stdin. Emits a per-repo
+# rollup: {"owner/repo": {commits: N, prs_opened: N, ..., days_active: [...]}}.
+# Items missing repo or date are dropped. days_active is unique-sorted.
+rollup_repos() {
+  jq '
+    def to_records(field; src; date_field):
+      (.[field] // []) | map({
+        repo,
+        source: src,
+        day: ((.[date_field] // "") | tostring | .[0:10])
+      });
+    [
+      to_records("commits"; "commits"; "date"),
+      to_records("prs_opened"; "prs_opened"; "createdAt"),
+      to_records("prs_reviewed"; "prs_reviewed"; "updatedAt"),
+      to_records("issues_opened"; "issues_opened"; "createdAt"),
+      to_records("issues_closed"; "issues_closed"; "closedAt"),
+      to_records("commented"; "commented"; "updatedAt")
+    ]
+    | add
+    | map(select(.repo != null and .day != ""))
+    | group_by(.repo)
+    | map({
+        key: .[0].repo,
+        value: (
+          reduce .[] as $i (
+            {commits: 0, prs_opened: 0, prs_reviewed: 0,
+             issues_opened: 0, issues_closed: 0, commented: 0,
+             days_active: []};
+            .[$i.source] += 1
+            | .days_active += [$i.day]
+          )
+          | .days_active |= (unique | sort)
+        )
+      })
+    | from_entries
+  '
+}
+
 fetch_events() {
   local since="$1" include="$2"
   if [[ "$include" != "true" ]]; then
@@ -186,7 +226,7 @@ main() {
   issues_closed_pkg=$(fetch_issues_closed "$since")
   commented_pkg=$(fetch_commented "$since")
 
-  local truncated
+  local truncated repos
   truncated=$(jq -nc \
     --argjson commits "$commits_pkg" \
     --argjson prs_opened "$prs_opened_pkg" \
@@ -201,12 +241,27 @@ main() {
       issues_closed: $issues_closed.raw_count,
       commented: $commented.raw_count}' | detect_truncated)
 
+  repos=$(jq -nc \
+    --argjson commits "$commits_pkg" \
+    --argjson prs_opened "$prs_opened_pkg" \
+    --argjson prs_reviewed "$prs_reviewed_pkg" \
+    --argjson issues_opened "$issues_opened_pkg" \
+    --argjson issues_closed "$issues_closed_pkg" \
+    --argjson commented "$commented_pkg" \
+    '{commits: $commits.items,
+      prs_opened: $prs_opened.items,
+      prs_reviewed: $prs_reviewed.items,
+      issues_opened: $issues_opened.items,
+      issues_closed: $issues_closed.items,
+      commented: $commented.items}' | rollup_repos)
+
   jq -n \
     --arg since "$since" \
     --arg now "$now" \
     --argjson include_events "$include_events" \
     --argjson limit "$LIMIT" \
     --argjson truncated "$truncated" \
+    --argjson repos "$repos" \
     --argjson commits "$commits_pkg" \
     --argjson prs_opened "$prs_opened_pkg" \
     --argjson prs_reviewed "$prs_reviewed_pkg" \
@@ -216,6 +271,7 @@ main() {
     --argjson events "$(fetch_events "$since" "$include_events")" \
     '{window: {since: $since, now: $now, events_included: $include_events,
                limit: $limit, truncated: $truncated},
+      repos: $repos,
       commits: $commits.items,
       prs_opened: $prs_opened.items,
       prs_reviewed: $prs_reviewed.items,

--- a/.claude/skills/digest/collect.sh
+++ b/.claude/skills/digest/collect.sh
@@ -69,6 +69,10 @@ filter_issues_opened() {
   jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, state, url, createdAt}]"
 }
 
+filter_issues_closed() {
+  jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, state, url, closedAt}]"
+}
+
 filter_commented() {
   jq "[.[] | {repo: $REPO_FROM_URL, n: .number, title, url, updatedAt}]"
 }
@@ -108,6 +112,11 @@ fetch_issues_opened() {
     --json number,title,state,url,createdAt 2>/dev/null | filter_issues_opened
 }
 
+fetch_issues_closed() {
+  gh search issues --author=@me --closed=">$1" --limit 100 \
+    --json number,title,state,url,closedAt 2>/dev/null | filter_issues_closed
+}
+
 fetch_commented() {
   gh search issues --commenter=@me --updated=">$1" --limit 100 \
     --json number,title,url,updatedAt 2>/dev/null | filter_commented
@@ -145,6 +154,7 @@ main() {
     --argjson prs_opened "$(fetch_prs_opened "$since")" \
     --argjson prs_reviewed "$(fetch_prs_reviewed "$since")" \
     --argjson issues_opened "$(fetch_issues_opened "$since")" \
+    --argjson issues_closed "$(fetch_issues_closed "$since")" \
     --argjson commented "$(fetch_commented "$since")" \
     --argjson events "$(fetch_events "$since" "$include_events")" \
     '{window: {since: $since, now: $now, events_included: $include_events},
@@ -152,6 +162,7 @@ main() {
       prs_opened: $prs_opened,
       prs_reviewed: $prs_reviewed,
       issues_opened: $issues_opened,
+      issues_closed: $issues_closed,
       commented: $commented,
       events: $events}'
 }

--- a/.claude/skills/digest/collect.sh
+++ b/.claude/skills/digest/collect.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 LAST_RUN_FILE="$SCRIPT_DIR/last-run"
 LOGIN=alunduil
+# gh's search API hard-caps at 1000; 300 covers observed spiky weeks
+# (~100s of PRs/issues) without ballooning synthesis-pass tokens.
+LIMIT=300
 
 SQUASH_MERGE_RE=' \(#[0-9]+\)$'
 SYNC_NOISE_REPO='alunduil/alunduil-claustre-state'
@@ -92,34 +95,62 @@ filter_events() {
     ]'
 }
 
+# Each fetch_* returns {raw_count, items} so main() can detect whether
+# a query saturated the limit (silent truncation is the worst failure).
+package() {
+  local raw="$1" filtered="$2"
+  jq -n --argjson n "$(jq 'length // 0' <<<"$raw")" \
+    --argjson i "$filtered" \
+    '{raw_count: $n, items: $i}'
+}
+
 fetch_commits() {
-  gh search commits --author=@me --author-date=">$1" --limit 100 \
-    --json repository,sha,commit 2>/dev/null | filter_commits
+  local raw
+  raw=$(gh search commits --author=@me --author-date=">$1" --limit "$LIMIT" \
+    --json repository,sha,commit 2>/dev/null)
+  package "$raw" "$(filter_commits <<<"$raw")"
 }
 
 fetch_prs_opened() {
-  gh search prs --author=@me --created=">$1" --limit 100 \
-    --json number,title,state,url,createdAt 2>/dev/null | filter_prs_opened
+  local raw
+  raw=$(gh search prs --author=@me --created=">$1" --limit "$LIMIT" \
+    --json number,title,state,url,createdAt 2>/dev/null)
+  package "$raw" "$(filter_prs_opened <<<"$raw")"
 }
 
 fetch_prs_reviewed() {
-  gh search prs --reviewed-by=@me --updated=">$1" --limit 100 \
-    --json number,title,url,author,updatedAt 2>/dev/null | filter_prs_reviewed
+  local raw
+  raw=$(gh search prs --reviewed-by=@me --updated=">$1" --limit "$LIMIT" \
+    --json number,title,url,author,updatedAt 2>/dev/null)
+  package "$raw" "$(filter_prs_reviewed <<<"$raw")"
 }
 
 fetch_issues_opened() {
-  gh search issues --author=@me --created=">$1" --limit 100 \
-    --json number,title,state,url,createdAt 2>/dev/null | filter_issues_opened
+  local raw
+  raw=$(gh search issues --author=@me --created=">$1" --limit "$LIMIT" \
+    --json number,title,state,url,createdAt 2>/dev/null)
+  package "$raw" "$(filter_issues_opened <<<"$raw")"
 }
 
 fetch_issues_closed() {
-  gh search issues --author=@me --closed=">$1" --limit 100 \
-    --json number,title,state,url,closedAt 2>/dev/null | filter_issues_closed
+  local raw
+  raw=$(gh search issues --author=@me --closed=">$1" --limit "$LIMIT" \
+    --json number,title,state,url,closedAt 2>/dev/null)
+  package "$raw" "$(filter_issues_closed <<<"$raw")"
 }
 
 fetch_commented() {
-  gh search issues --commenter=@me --updated=">$1" --limit 100 \
-    --json number,title,url,updatedAt 2>/dev/null | filter_commented
+  local raw
+  raw=$(gh search issues --commenter=@me --updated=">$1" --limit "$LIMIT" \
+    --json number,title,url,updatedAt 2>/dev/null)
+  package "$raw" "$(filter_commented <<<"$raw")"
+}
+
+# Reads {name: raw_count, ...} on stdin, emits sorted array of names
+# whose count saturated the limit.
+detect_truncated() {
+  jq --argjson limit "$LIMIT" \
+    '[to_entries[] | select(.value >= $limit) | .key] | sort'
 }
 
 fetch_events() {
@@ -146,24 +177,51 @@ main() {
     include_events=false
   fi
 
+  local commits_pkg prs_opened_pkg prs_reviewed_pkg
+  local issues_opened_pkg issues_closed_pkg commented_pkg
+  commits_pkg=$(fetch_commits "$since")
+  prs_opened_pkg=$(fetch_prs_opened "$since")
+  prs_reviewed_pkg=$(fetch_prs_reviewed "$since")
+  issues_opened_pkg=$(fetch_issues_opened "$since")
+  issues_closed_pkg=$(fetch_issues_closed "$since")
+  commented_pkg=$(fetch_commented "$since")
+
+  local truncated
+  truncated=$(jq -nc \
+    --argjson commits "$commits_pkg" \
+    --argjson prs_opened "$prs_opened_pkg" \
+    --argjson prs_reviewed "$prs_reviewed_pkg" \
+    --argjson issues_opened "$issues_opened_pkg" \
+    --argjson issues_closed "$issues_closed_pkg" \
+    --argjson commented "$commented_pkg" \
+    '{commits: $commits.raw_count,
+      prs_opened: $prs_opened.raw_count,
+      prs_reviewed: $prs_reviewed.raw_count,
+      issues_opened: $issues_opened.raw_count,
+      issues_closed: $issues_closed.raw_count,
+      commented: $commented.raw_count}' | detect_truncated)
+
   jq -n \
     --arg since "$since" \
     --arg now "$now" \
     --argjson include_events "$include_events" \
-    --argjson commits "$(fetch_commits "$since")" \
-    --argjson prs_opened "$(fetch_prs_opened "$since")" \
-    --argjson prs_reviewed "$(fetch_prs_reviewed "$since")" \
-    --argjson issues_opened "$(fetch_issues_opened "$since")" \
-    --argjson issues_closed "$(fetch_issues_closed "$since")" \
-    --argjson commented "$(fetch_commented "$since")" \
+    --argjson limit "$LIMIT" \
+    --argjson truncated "$truncated" \
+    --argjson commits "$commits_pkg" \
+    --argjson prs_opened "$prs_opened_pkg" \
+    --argjson prs_reviewed "$prs_reviewed_pkg" \
+    --argjson issues_opened "$issues_opened_pkg" \
+    --argjson issues_closed "$issues_closed_pkg" \
+    --argjson commented "$commented_pkg" \
     --argjson events "$(fetch_events "$since" "$include_events")" \
-    '{window: {since: $since, now: $now, events_included: $include_events},
-      commits: $commits,
-      prs_opened: $prs_opened,
-      prs_reviewed: $prs_reviewed,
-      issues_opened: $issues_opened,
-      issues_closed: $issues_closed,
-      commented: $commented,
+    '{window: {since: $since, now: $now, events_included: $include_events,
+               limit: $limit, truncated: $truncated},
+      commits: $commits.items,
+      prs_opened: $prs_opened.items,
+      prs_reviewed: $prs_reviewed.items,
+      issues_opened: $issues_opened.items,
+      issues_closed: $issues_closed.items,
+      commented: $commented.items,
       events: $events}'
 }
 

--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -1,0 +1,26 @@
+---
+name: Idea
+about: A spark for a future blog post — not yet ready to draft.
+title: ""
+labels: idea
+---
+
+## Spark
+
+<!-- 1-2 sentences. Where this came from: digest item, conversation, link, observation. -->
+
+## Why it could be interesting
+
+<!-- 1-2 sentences. The angle that isn't already obvious from existing writing on the topic. -->
+
+## Open questions
+
+<!-- What you'd need to figure out before drafting. Bulleted. -->
+
+- [ ]
+
+## Source material
+
+<!-- Links: GitHub item, highlight, article, prior post, conversation transcript. -->
+
+-

--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -11,7 +11,7 @@ labels: idea
 
 ## Why it could be interesting
 
-<!-- 1-2 sentences. The angle that isn't already obvious from existing writing on the topic. -->
+<!-- Push past the surface. The activity ("I migrated to Renovate") isn't the post — the underlying claim is ("dependency-update toil scales superlinearly with repo count, here's where the threshold sits"). 1-2 sentences on the actual claim, not the activity. -->
 
 ## Open questions
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+---
+# Pre-commit hooks for code quality and consistency.
+# See https://pre-commit.com for usage.
+
+repos:
+  # Shell linting and formatting (digest skill collect.sh and any future scripts)
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        types: [shell]
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.12.0-2
+    hooks:
+      - id: shfmt
+        args: [-i, "2", -ci]
+        types: [shell]
+
+  # Baseline file hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-json
+        # AstroPaper ships JSONC files in .vscode/ and .devcontainer/.
+        exclude: ^(\.vscode/|\.devcontainer/)
+      - id: check-yaml
+        exclude: ^\.github/workflows/
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key


### PR DESCRIPTION
## Summary

Adds `/digest`: a slash command for cadence-driven (`7d`, `4w`, `last`) review of GitHub activity, Readwise highlights, and Reader archives, surfacing raw material for blog post brainstorming. Promising kernels file via `gh issue create --template idea`.

## Gotchas

- **Heuristic filters in `collect.sh` encode my workflow** and ossify after merge. Confirm: `task/*` and `release-please--*` `CreateEvent` skip, `\s\(#\d+\)$` squash-merge dedup, `alunduil/alunduil-claustre-state` repo + `^sync: ` subject skip.
- **Bats tests collocated** at `.claude/skills/digest/collect.bats` instead of `test/` (the chezmoi convention). Speak up if you'd prefer the conventional path; #62 (bats CI) reflects the current choice.
- **`commits` will land in `window.truncated` most weeks** because raw search returns 300 and squash-dedup strips most. SKILL.md tells synthesis to discount commits-only truncation; worth a sanity check vs. just hard-excluding `commits` from the truncation list.
- **`.pre-commit-config.yaml` will auto-fix 27 inherited AstroPaper template files** on the next `pre-commit run --all-files`. Reverted here; tracked as #63.

## Verification

- 32/32 bats; pre-commit clean (no CI runs either yet).
- `bash .claude/skills/digest/collect.sh 7d` on real data — 16 repos rolled up with `days_active` heatmaps, `window.truncated` reports as expected.

## Related (not blocking)

#58 markdownlint · #59 yamllint · #60 lychee · #61 Vale · #62 bats CI · #63 baseline pre-commit cleanup