### PR TITLE
Auto-label idea issues

### DIFF
--- a/.github/workflows/label-ideas.yml
+++ b/.github/workflows/label-ideas.yml
@@ -1,0 +1,19 @@
+name: Label idea issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    if: contains(github.event.issue.body, '## Spark')
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue edit "$NUMBER" --repo "$REPO" --add-label idea
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,4 @@
-name: Label idea issues
+name: Labels
 
 on:
   issues:
@@ -8,7 +8,7 @@ permissions:
   issues: write
 
 jobs:
-  label:
+  ideas:
     if: contains(github.event.issue.body, '## Spark')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Idea kernels filed via `gh issue create --template idea` were landing
unlabeled — the template's frontmatter `labels: idea` is only honored
by GitHub's web UI, not the CLI. A new `Labels` workflow with an
`ideas` job applies the label on `issues: opened` whenever the body
contains the template's `## Spark` heading, so the label is reliable
regardless of how the issue was filed.

The workflow is named generically with room to grow: future label
rules (e.g. PR path-based labels) land as additional jobs in the
same file rather than separate `label-*.yml` workflows.

Backfilled the 9 affected issues separately: #66, #67, #68, #69, #71,
#72, #73, #74, #75.

## Gotchas

The `ideas` job triggers on a substring match of `## Spark` in the
issue body. Any non-idea issue that happens to include that exact
heading would also get labeled — low-probability collision, but
worth knowing.

## Verification

- [ ] Open a throwaway test issue from the idea template after merge,
      confirm the workflow applies the `idea` label, then close it.