### PR TITLE
Run bats tests in CI on every PR

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,0 +1,33 @@
+name: Bats
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          # Override defaults of true; skill tests don't load helper libs.
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+          # bats-action curls api.github.com; auth raises the anonymous rate limit.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test
+        # -r recurses; future skills with *.bats files are picked up automatically.
+        run: bats -r .claude/skills


### PR DESCRIPTION
## Summary

Bats tests under `.claude/skills/*/` now run on every PR via a new `Bats`
GitHub Actions workflow, so digest-skill regressions surface in CI instead
of only locally.

## Gotchas

- Test discovery uses `bats -r .claude/skills` — bats's native recursion.
  Picks up any future skill's collocated `*.bats` without workflow edits;
  the alternative explicit-list policy was rejected because it would need
  updating per skill, which fights the self-contained-bundle layout.
- Workflow shape mirrors `alunduil-chezmoi`'s `bats.yml`: SHA-pinned
  actions, `contents: read`, PR-only `cancel-in-progress`, `ubuntu-24.04`,
  10-minute timeout, helper-lib auto-installs disabled, `github-token`
  passed to lift bats-action's anonymous rate limit.

## Verification

- Ran `bats -r .claude/skills` locally — 32/32 pass (Bats 1.8.2).
- CI run on this PR is the live check for the workflow itself; merging
  blocks on the green Bats check.

Closes #62