### PR TITLE
Correct branch model in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,8 @@ Customized and free to edit: `src/config.ts`, `src/constants.ts`,
 
 ## Branches and deploy
 
-- Default branch: `develop`. PRs target `develop`.
-- Deploy runs on push to `main` (`.github/workflows/deploy.yml`). `main`
-  doesn't exist yet — first publish creates it from `develop`.
+- Default branch: `main`. PRs target `main`.
+- Deploy runs on push to `main` (`.github/workflows/deploy.yml`).
 
 ## Digest skill
 


### PR DESCRIPTION
## Summary

CLAUDE.md's `Branches and deploy` section claimed `develop` was the default and `main` didn't exist yet. Reality: `main` is the default, `develop` is gone, and PRs (including Renovate's) target `main`. This corrects the section so future agents route to the right branch.

Surfaced while addressing #90 — Renovate's dashboard had been skipping with "Base branch does not exist" against the same stale assumption (now ticked the manual-job checkbox; Renovate has re-scanned, opened #91 and #92, and the warning is gone). #90 stays open as Renovate's persistent dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)