### PR TITLE
Pin deploy workflow to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: withastro/action@56781b97402ce0487b7e61ce2cb960c0e2cc5289 # v3
         with:
+          node-version: "22"
           package-manager: pnpm@latest
 
   deploy:


### PR DESCRIPTION
## Summary

Deploy now runs on push to `main` end-to-end. Pinning `node-version: "22"` on `withastro/action` aligns the runtime with `pnpm@latest`, which had been failing with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` because pnpm 11.0.9 requires Node ≥22.13 and the action defaults to Node 20.

The other acceptance criteria in #50 are already in place (default = `main`, `develop` deleted, Pages enabled with workflow source, custom domain provisioned via Terraform in alunduil-infrastructure#7).

## Verification

- [ ] Workflow run for this PR / merge to `main` is green.
- [ ] `https://blog.alunduil.com/` serves the built site after merge.

Closes #50