### PR TITLE
Lint YAML cleanly via yamllint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
         args: [-i, "2", -ci]
         types: [shell]
 
+  # YAML linting (workflows, frontmatter, pre-commit config itself)
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+
   # Baseline file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: relaxed
+
+ignore: |
+  pnpm-lock.yaml
+  node_modules/
+  .vale/styles/


### PR DESCRIPTION
## Summary

Workflows, the idea-template frontmatter, and `.pre-commit-config.yaml` itself now lint cleanly via yamllint on commit, matching the pattern in chezmoi and woodland-generators.

Rule choice: **relaxed**. The blog repo's YAML surface is small and content-adjacent (3 workflows, one issue-template frontmatter, the pre-commit config). Strict is reserved for infrastructure where YAML drift is consequential — overkill here. `pnpm-lock.yaml` is ignored as a generated artifact.

## Verification

- `pre-commit run --all-files` passes (all 15 hooks green, including the new yamllint).

Closes #59