### PR TITLE
Pin pnpm in deploy workflow under Renovate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: withastro/action@56781b97402ce0487b7e61ce2cb960c0e2cc5289 # v3
         with:
-          package-manager: pnpm@latest
+          package-manager: pnpm@10.33.4
 
   deploy:
     needs: build

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,14 @@
   "reviewers": ["alunduil"],
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/deploy\\.yml$/"],
+      "matchStrings": ["package-manager:\\s*pnpm@(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "pnpm",
+      "datasourceTemplate": "npm"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Deploy no longer rides whatever `pnpm@latest` resolves to at run time — pinned to `pnpm@10.33.4` and governed by Renovate so version moves arrive as PRs.

## Gotchas

The custom regex manager only matches `package-manager:\s*pnpm@<version>` in `.github/workflows/deploy.yml`. If another workflow gains a `pnpm@…` pin, extend `managerFilePatterns` rather than copy-pasting the manager.

## Verification

- `renovate.json` validates against the published schema (matches the user-level skill's Defaults block plus one `customManagers` entry).
- Starting version `10.33.4` matches the local `pnpm --version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)