### PR TITLE
Run pre-commit in CI on every PR

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+name: Pre-commit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.x'
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Summary

Pre-commit now runs on every push to main and every PR, so contributors without the local hook can't land hygiene regressions silently. Aligns with the `pre-commit.yml` shape used in `alunduil-chezmoi` and four other alunduil repos.

## Verification

- `pre-commit run --all-files` locally → all hooks pass, no modifications.
- Workflow shape mirrors chezmoi's: SHA-pinned `actions/checkout`, `actions/setup-python`, `pre-commit/action@v3.0.1`; `permissions: contents: read`; concurrency cancels superseded PR runs but never main.

## Gotchas

- The issue body said `push to develop`; corrected to `main` to match this repo's default branch and the chezmoi model.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)