### PR TITLE
Wire markdownlint-cli2 into pre-commit hooks

### DIFF
--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -7,11 +7,15 @@ labels: idea
 
 ## Spark
 
-<!-- 1-2 sentences. Where this came from: digest item, conversation, link, observation. -->
+<!-- 1-2 sentences. Where this came from: digest item, conversation,
+link, observation. -->
 
 ## Why it could be interesting
 
-<!-- Push past the surface. The activity ("I migrated to Renovate") isn't the post — the underlying claim is ("dependency-update toil scales superlinearly with repo count, here's where the threshold sits"). 1-2 sentences on the actual claim, not the activity. -->
+<!-- Push past the surface. The activity ("I migrated to Renovate")
+isn't the post — the underlying claim is ("dependency-update toil
+scales superlinearly with repo count, here's where the threshold
+sits"). 1-2 sentences on the actual claim, not the activity. -->
 
 ## Open questions
 
@@ -21,6 +25,7 @@ labels: idea
 
 ## Source material
 
-<!-- Links: GitHub item, highlight, article, prior post, conversation transcript. -->
+<!-- Links: GitHub item, highlight, article, prior post, conversation
+transcript. -->
 
 -

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,24 @@
+---
+# markdownlint rules tuned for this repo's content.
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+config:
+  # Use ATX-style headings (# Heading) consistently.
+  MD003:
+    style: atx
+  # Long lines are fine inside code blocks, headings, and tables.
+  MD013:
+    code_blocks: false
+    headings: false
+    tables: false
+  # Allow repeated headings at different nesting levels.
+  MD024:
+    siblings_only: true
+  # AstroPaper posts may use a small set of inline HTML for typography.
+  MD033:
+    allowed_elements:
+      - br
+      - kbd
+      - sub
+      - sup
+  # Posts start with frontmatter, not an H1.
+  MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         name: Lint prose with Vale
         args: ["--config=.vale.ini"]
         types: [markdown]
-        exclude: |
+        exclude: &upstream_md_exclude |
           (?x)^(
             CLAUDE\.md|
             \.claude/.*|
@@ -68,3 +68,12 @@ repos:
               setting-dates-via-git-hooks\.md
             )
           )$
+
+  # Markdown structure linting with markdownlint-cli2.
+  # Same exclude as Vale: AstroPaper upstream content + AI-targeted markdown.
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+        args: [--fix]
+        exclude: *upstream_md_exclude

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -3,10 +3,16 @@ layout: ../layouts/AboutLayout.astro
 title: "About"
 ---
 
-I'm Alex Brandt—a Production Software Engineer drawn to reliability, observability, and systems with strong feedback loops.
+I'm Alex Brandt—a Production Software Engineer drawn to reliability,
+observability, and systems with strong feedback loops.
 
-This is where I keep notes from that work: weekly learnings from projects, dev environment setups I've found worth keeping, interesting solutions I've come across or implemented, and short blurbs on things I'm building and how to use them.
+This is where I keep notes from that work: weekly learnings from
+projects, dev environment setups I've found worth keeping, interesting
+solutions I've come across or implemented, and short blurbs on things
+I'm building and how to use them.
 
-The goal is a corpus rather than a publication—pieces are short, opinionated, and likely to evolve as I learn more.
+The goal is a corpus rather than a publication—pieces are short,
+opinionated, and likely to evolve as I learn more.
 
-If something here is useful or off-base, [reach out](mailto:alunduil@gmail.com).
+If something here is useful or off-base,
+[reach out](mailto:alunduil@gmail.com).


### PR DESCRIPTION
## Summary

Repo markdown lints cleanly under markdownlint-cli2 via pre-commit,
matching the structural-linting tier the other active repos already
have. AstroPaper upstream content and AI-targeted markdown stay
excluded (same regex as Vale). Closes #58.

## Gotchas

- **cli vs cli2**: picked `markdownlint-cli2` over `markdownlint-cli`.
  Same author, recommended by upstream, cleaner config discovery
  (single `.markdownlint-cli2.yaml`), and matches the most-recent of
  the three reference configs (alunduil-infrastructure).
- **Exclude pattern reuse**: Vale's exclude regex is now a YAML anchor
  (`&upstream_md_exclude`) reused by the markdownlint hook. Diverging
  the two lists later means dropping the anchor; flag it if a use
  case for that appears.
- **MD013 still on for prose**: kept woodland's relaxation set
  (code/headings/tables only), so prose lines still get the 80-char
  cap. Hard-wrapped six existing violations in about.md and the idea
  template at ~72 cols to match README.md's style. If a future post
  pushes back on this, drop MD013 in `.markdownlint-cli2.yaml` rather
  than wrapping every paragraph.

## Verification

- Ran `pre-commit run --all-files` — clean.