### PR TITLE
Fix LinkedIn footer link to alunduil

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const SOCIALS: Social[] = [
   },
   {
     name: "LinkedIn",
-    href: "https://www.linkedin.com/in/albrandt/",
+    href: "https://www.linkedin.com/in/alunduil/",
     linkTitle: `${SITE.author} on LinkedIn`,
     icon: IconLinkedin,
   },


### PR DESCRIPTION
## Summary

Footer LinkedIn link now points at the real profile (`linkedin.com/in/alunduil/`) instead of the `albrandt` placeholder carried over from the original AstroPaper port.

## Verification

- Confirmed via `git blame` that the placeholder originated in the AstroPaper port commit (b7f806c), not in any subsequent edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)