### PR TITLE
Add lychee link checker on push and PR

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,0 +1,29 @@
+name: Lychee
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs; never cancel main so each commit completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: .lycheecache
+          key: lychee-cache-${{ hashFiles('lychee.toml', '**/*.md') }}
+          restore-keys: lychee-cache-
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: '**/*.md'

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ pnpm-debug.log*
 # pagefind
 
 public/pagefind
+
+# lychee link-checker cache
+.lycheecache

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,12 @@
+cache = true
+max_cache_age = "14d"
+retry_wait_time = 5
+include_fragments = "full"
+
+# Skip vendored upstream content. AstroPaper tutorials per CLAUDE.md;
+# .vale/styles/ are upstream Vale style packages.
+exclude_path = [
+  "(^|/)\\.vale/styles/",
+  "(^|/)src/data/blog/(_releases|examples)/",
+  "(^|/)src/data/blog/(adding-new-post|customizing-.*|dynamic-og-images|how-to-.*|predefined-color-schemes|setting-dates-via-git-hooks)\\.md$",
+]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,7 +1,7 @@
 cache = true
 max_cache_age = "14d"
 retry_wait_time = 5
-include_fragments = "full"
+include_fragments = true
 
 # Skip vendored upstream content. AstroPaper tutorials per CLAUDE.md;
 # .vale/styles/ are upstream Vale style packages.


### PR DESCRIPTION
## Summary

Repo now fails CI on dead markdown links. A dedicated `Lychee` workflow runs on push to `main` and on every PR, mirroring the `alunduil-chezmoi` pattern — workflow-only invocation, no pre-commit hook.

`lychee.toml` carries the chezmoi defaults (cache, 14d TTL, retry, fragment checking) plus an `exclude_path` covering AstroPaper upstream tutorials and the vendored `.vale/styles/` READMEs. Same scope CLAUDE.md and the Vale pre-commit hook already treat as upstream, so we don't take responsibility for fixing link rot in content the project doesn't own.

## Gotchas

- Issue body asserted "other repos run it via pre-commit AND a dedicated workflow" — actually chezmoi has workflow-only and woodland-generators has pre-commit-only. Followed chezmoi's pattern after re-checking.
- `include_fragments = true` (boolean), tracking chezmoi exactly. The string `"full"` form was introduced in lychee 0.24+; `lycheeverse/lychee-action@v2.8.0` ships lychee v0.23.0, so the boolean is required for CI to parse the config. Local lychee 0.24.x won't load this file as-is — install 0.23.x to reproduce CI locally.
- `exclude_path` regex uses `(^|/)` so it matches whether the path is fed as `src/...` or `./src/...`.

## Verification

- pre-commit passes on the changed files.
- Watching CI on this PR for the green Lychee run.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)