### PR TITLE
Tint mobile chrome to site palette via theme-color

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -114,7 +114,16 @@ const structuredData = {
       href={new URL("rss.xml", Astro.site)}
     />
 
-    <meta name="theme-color" content="" />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: light)"
+      content="#F4EFE6"
+    />
+    <meta
+      name="theme-color"
+      media="(prefers-color-scheme: dark)"
+      content="#0A0A0A"
+    />
 
     {
       // If PUBLIC_GOOGLE_SITE_VERIFICATION is set in the environment variable,


### PR DESCRIPTION
## Summary

Mobile browser chrome (Safari address bar, Android status bar, PWA
chrome) now tints to the site palette — canvas `#F4EFE6` in light mode
and grid `#0A0A0A` in dark mode — instead of falling back to default
chrome unrelated to the site.

## Verification

- `pnpm astro check` — 0 errors.
- Mobile Safari and Android Chrome verification (per acceptance
  criteria) pending — needs a deploy preview / staging URL on a phone.

Closes #134