### PR TITLE
Render dynamic OG cards in Mondrian style

### DIFF
--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -36,14 +36,14 @@ async function loadGoogleFonts(
 > {
   const fontsConfig = [
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "IBM Plex Sans",
+      font: "IBM+Plex+Sans",
       weight: 400,
       style: "normal",
     },
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "IBM Plex Sans",
+      font: "IBM+Plex+Sans",
       weight: 700,
       style: "bold",
     },

--- a/src/utils/og-templates/mondrian.js
+++ b/src/utils/og-templates/mondrian.js
@@ -1,0 +1,14 @@
+export const COLORS = {
+  cream: "#F4EFE6",
+  black: "#0A0A0A",
+  red: "#D5232A",
+  blue: "#1E4FA1",
+  yellow: "#F1C232",
+};
+
+export const STROKE = 8;
+
+export const block = (background, extra = {}) => ({
+  type: "div",
+  props: { style: { background, display: "flex", ...extra } },
+});

--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -4,10 +4,10 @@ import loadGoogleFonts from "../loadGoogleFont";
 import { COLORS, STROKE, block } from "./mondrian";
 
 const formatDate = (date, timezone) =>
-  new Intl.DateTimeFormat("en-GB", {
+  new Intl.DateTimeFormat("sv-SE", {
     year: "numeric",
-    month: "short",
-    day: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     timeZone: timezone,
   }).format(date);
 

--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -1,217 +1,156 @@
 import satori from "satori";
-// import { html } from "satori-html";
 import { SITE } from "@/config";
 import loadGoogleFonts from "../loadGoogleFont";
 
-// const markup = html`<div
-//       style={{
-//         background: "#fefbfb",
-//         width: "100%",
-//         height: "100%",
-//         display: "flex",
-//         alignItems: "center",
-//         justifyContent: "center",
-//       }}
-//     >
-//       <div
-//         style={{
-//           position: "absolute",
-//           top: "-1px",
-//           right: "-1px",
-//           border: "4px solid #000",
-//           background: "#ecebeb",
-//           opacity: "0.9",
-//           borderRadius: "4px",
-//           display: "flex",
-//           justifyContent: "center",
-//           margin: "2.5rem",
-//           width: "88%",
-//           height: "80%",
-//         }}
-//       />
+const COLORS = {
+  cream: "#F4EFE6",
+  black: "#0A0A0A",
+  red: "#D5232A",
+  blue: "#1E4FA1",
+  yellow: "#F1C232",
+};
 
-//       <div
-//         style={{
-//           border: "4px solid #000",
-//           background: "#fefbfb",
-//           borderRadius: "4px",
-//           display: "flex",
-//           justifyContent: "center",
-//           margin: "2rem",
-//           width: "88%",
-//           height: "80%",
-//         }}
-//       >
-//         <div
-//           style={{
-//             display: "flex",
-//             flexDirection: "column",
-//             justifyContent: "space-between",
-//             margin: "20px",
-//             width: "90%",
-//             height: "90%",
-//           }}
-//         >
-//           <p
-//             style={{
-//               fontSize: 72,
-//               fontWeight: "bold",
-//               maxHeight: "84%",
-//               overflow: "hidden",
-//             }}
-//           >
-//             {post.data.title}
-//           </p>
-//           <div
-//             style={{
-//               display: "flex",
-//               justifyContent: "space-between",
-//               width: "100%",
-//               marginBottom: "8px",
-//               fontSize: 28,
-//             }}
-//           >
-//             <span>
-//               by{" "}
-//               <span
-//                 style={{
-//                   color: "transparent",
-//                 }}
-//               >
-//                 "
-//               </span>
-//               <span style={{ overflow: "hidden", fontWeight: "bold" }}>
-//                 {post.data.author}
-//               </span>
-//             </span>
+const STROKE = 8;
 
-//             <span style={{ overflow: "hidden", fontWeight: "bold" }}>
-//               {SITE.title}
-//             </span>
-//           </div>
-//         </div>
-//       </div>
-//     </div>`;
+const block = (background, extra = {}) => ({
+  type: "div",
+  props: { style: { background, display: "flex", ...extra } },
+});
+
+const formatDate = (date, timezone) =>
+  new Intl.DateTimeFormat("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: timezone,
+  }).format(date);
 
 export default async post => {
+  const hostname = new URL(SITE.website).hostname;
+  const pubDate = formatDate(
+    post.data.pubDatetime,
+    post.data.timezone ?? SITE.timezone
+  );
+  const titleSize = post.data.title.length > 60 ? 64 : 84;
+
   return satori(
     {
       type: "div",
       props: {
         style: {
-          background: "#fefbfb",
           width: "100%",
           height: "100%",
           display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
+          flexDirection: "column",
+          background: COLORS.black,
+          padding: STROKE,
+          gap: STROKE,
+          fontFamily: "IBM Plex Sans",
+          color: COLORS.black,
         },
         children: [
           {
             type: "div",
             props: {
               style: {
-                position: "absolute",
-                top: "-1px",
-                right: "-1px",
-                border: "4px solid #000",
-                background: "#ecebeb",
-                opacity: "0.9",
-                borderRadius: "4px",
                 display: "flex",
-                justifyContent: "center",
-                margin: "2.5rem",
-                width: "88%",
-                height: "80%",
+                flexDirection: "row",
+                gap: STROKE,
+                height: 96,
               },
+              children: [
+                block(COLORS.red, { width: 280 }),
+                block(COLORS.cream, { flex: 1 }),
+                block(COLORS.blue, { width: 120 }),
+                block(COLORS.yellow, { width: 200 }),
+              ],
             },
           },
           {
             type: "div",
             props: {
               style: {
-                border: "4px solid #000",
-                background: "#fefbfb",
-                borderRadius: "4px",
                 display: "flex",
-                justifyContent: "center",
-                margin: "2rem",
-                width: "88%",
-                height: "80%",
+                flexDirection: "row",
+                gap: STROKE,
+                flex: 1,
               },
-              children: {
-                type: "div",
-                props: {
-                  style: {
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "space-between",
-                    margin: "20px",
-                    width: "90%",
-                    height: "90%",
+              children: [
+                block(COLORS.blue, { width: 96 }),
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      flex: 1,
+                      background: COLORS.cream,
+                      display: "flex",
+                      flexDirection: "column",
+                      justifyContent: "center",
+                      padding: "32px 64px",
+                      overflow: "hidden",
+                    },
+                    children: [
+                      {
+                        type: "div",
+                        props: {
+                          style: {
+                            fontSize: titleSize,
+                            fontWeight: 700,
+                            lineHeight: 1.1,
+                            letterSpacing: "-0.01em",
+                            overflow: "hidden",
+                          },
+                          children: post.data.title,
+                        },
+                      },
+                    ],
                   },
-                  children: [
-                    {
-                      type: "p",
-                      props: {
-                        style: {
-                          fontSize: 72,
-                          fontWeight: "bold",
-                          maxHeight: "84%",
-                          overflow: "hidden",
-                        },
-                        children: post.data.title,
-                      },
-                    },
-                    {
-                      type: "div",
-                      props: {
-                        style: {
-                          display: "flex",
-                          justifyContent: "space-between",
-                          width: "100%",
-                          marginBottom: "8px",
-                          fontSize: 28,
-                        },
-                        children: [
-                          {
-                            type: "span",
-                            props: {
-                              children: [
-                                "by ",
-                                {
-                                  type: "span",
-                                  props: {
-                                    style: { color: "transparent" },
-                                    children: '"',
-                                  },
-                                },
-                                {
-                                  type: "span",
-                                  props: {
-                                    style: {
-                                      overflow: "hidden",
-                                      fontWeight: "bold",
-                                    },
-                                    children: post.data.author,
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                          {
-                            type: "span",
-                            props: {
-                              style: { overflow: "hidden", fontWeight: "bold" },
-                              children: SITE.title,
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
                 },
+                block(COLORS.yellow, { width: 120 }),
+              ],
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                flexDirection: "row",
+                gap: STROKE,
+                height: 132,
               },
+              children: [
+                block(COLORS.yellow, { width: 96 }),
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      flex: 1,
+                      background: COLORS.cream,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      padding: "0 56px",
+                      fontSize: 28,
+                    },
+                    children: [
+                      {
+                        type: "div",
+                        props: { children: pubDate },
+                      },
+                      {
+                        type: "div",
+                        props: {
+                          style: { fontWeight: 700 },
+                          children: hostname,
+                        },
+                      },
+                    ],
+                  },
+                },
+                block(COLORS.blue, { width: 120 }),
+                block(COLORS.red, { width: 220 }),
+              ],
             },
           },
         ],
@@ -221,9 +160,7 @@ export default async post => {
       width: 1200,
       height: 630,
       embedFont: true,
-      fonts: await loadGoogleFonts(
-        post.data.title + post.data.author + SITE.title + "by"
-      ),
+      fonts: await loadGoogleFonts(post.data.title + pubDate + hostname),
     }
   );
 };

--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -1,21 +1,7 @@
 import satori from "satori";
 import { SITE } from "@/config";
 import loadGoogleFonts from "../loadGoogleFont";
-
-const COLORS = {
-  cream: "#F4EFE6",
-  black: "#0A0A0A",
-  red: "#D5232A",
-  blue: "#1E4FA1",
-  yellow: "#F1C232",
-};
-
-const STROKE = 8;
-
-const block = (background, extra = {}) => ({
-  type: "div",
-  props: { style: { background, display: "flex", ...extra } },
-});
+import { COLORS, STROKE, block } from "./mondrian";
 
 const formatDate = (date, timezone) =>
   new Intl.DateTimeFormat("en-GB", {

--- a/src/utils/og-templates/site.js
+++ b/src/utils/og-templates/site.js
@@ -2,117 +2,152 @@ import satori from "satori";
 import { SITE } from "@/config";
 import loadGoogleFonts from "../loadGoogleFont";
 
+const COLORS = {
+  cream: "#F4EFE6",
+  black: "#0A0A0A",
+  red: "#D5232A",
+  blue: "#1E4FA1",
+  yellow: "#F1C232",
+};
+
+const STROKE = 8;
+
+const block = (background, extra = {}) => ({
+  type: "div",
+  props: { style: { background, display: "flex", ...extra } },
+});
+
 export default async () => {
+  const hostname = new URL(SITE.website).hostname;
+
   return satori(
     {
       type: "div",
       props: {
         style: {
-          background: "#fefbfb",
           width: "100%",
           height: "100%",
           display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
+          flexDirection: "column",
+          background: COLORS.black,
+          padding: STROKE,
+          gap: STROKE,
+          fontFamily: "IBM Plex Sans",
+          color: COLORS.black,
         },
         children: [
           {
             type: "div",
             props: {
               style: {
-                position: "absolute",
-                top: "-1px",
-                right: "-1px",
-                border: "4px solid #000",
-                background: "#ecebeb",
-                opacity: "0.9",
-                borderRadius: "4px",
                 display: "flex",
-                justifyContent: "center",
-                margin: "2.5rem",
-                width: "88%",
-                height: "80%",
+                flexDirection: "row",
+                gap: STROKE,
+                height: 96,
               },
+              children: [
+                block(COLORS.red, { width: 280 }),
+                block(COLORS.cream, { flex: 1 }),
+                block(COLORS.blue, { width: 120 }),
+                block(COLORS.yellow, { width: 200 }),
+              ],
             },
           },
           {
             type: "div",
             props: {
               style: {
-                border: "4px solid #000",
-                background: "#fefbfb",
-                borderRadius: "4px",
                 display: "flex",
-                justifyContent: "center",
-                margin: "2rem",
-                width: "88%",
-                height: "80%",
+                flexDirection: "row",
+                gap: STROKE,
+                flex: 1,
               },
-              children: {
-                type: "div",
-                props: {
-                  style: {
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "space-between",
-                    margin: "20px",
-                    width: "90%",
-                    height: "90%",
+              children: [
+                block(COLORS.blue, { width: 96 }),
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      flex: 1,
+                      background: COLORS.cream,
+                      display: "flex",
+                      flexDirection: "column",
+                      justifyContent: "center",
+                      alignItems: "flex-start",
+                      padding: "32px 64px",
+                    },
+                    children: [
+                      {
+                        type: "div",
+                        props: {
+                          style: {
+                            fontSize: 168,
+                            fontWeight: 700,
+                            lineHeight: 1,
+                            letterSpacing: "-0.02em",
+                          },
+                          children: SITE.title,
+                        },
+                      },
+                      {
+                        type: "div",
+                        props: {
+                          style: {
+                            fontSize: 28,
+                            fontWeight: 400,
+                            marginTop: 28,
+                            maxWidth: "92%",
+                            lineHeight: 1.35,
+                          },
+                          children: SITE.desc,
+                        },
+                      },
+                    ],
                   },
-                  children: [
-                    {
-                      type: "div",
-                      props: {
-                        style: {
-                          display: "flex",
-                          flexDirection: "column",
-                          justifyContent: "center",
-                          alignItems: "center",
-                          height: "90%",
-                          maxHeight: "90%",
-                          overflow: "hidden",
-                          textAlign: "center",
-                        },
-                        children: [
-                          {
-                            type: "p",
-                            props: {
-                              style: { fontSize: 72, fontWeight: "bold" },
-                              children: SITE.title,
-                            },
-                          },
-                          {
-                            type: "p",
-                            props: {
-                              style: { fontSize: 28 },
-                              children: SITE.desc,
-                            },
-                          },
-                        ],
-                      },
-                    },
-                    {
-                      type: "div",
-                      props: {
-                        style: {
-                          display: "flex",
-                          justifyContent: "flex-end",
-                          width: "100%",
-                          marginBottom: "8px",
-                          fontSize: 28,
-                        },
-                        children: {
-                          type: "span",
-                          props: {
-                            style: { overflow: "hidden", fontWeight: "bold" },
-                            children: new URL(SITE.website).hostname,
-                          },
-                        },
-                      },
-                    },
-                  ],
                 },
+                block(COLORS.yellow, { width: 120 }),
+              ],
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                flexDirection: "row",
+                gap: STROKE,
+                height: 132,
               },
+              children: [
+                block(COLORS.yellow, { width: 96 }),
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      flex: 1,
+                      background: COLORS.cream,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "space-between",
+                      padding: "0 64px",
+                      fontSize: 32,
+                      fontWeight: 700,
+                    },
+                    children: [
+                      {
+                        type: "div",
+                        props: { children: SITE.author },
+                      },
+                      {
+                        type: "div",
+                        props: { children: hostname },
+                      },
+                    ],
+                  },
+                },
+                block(COLORS.blue, { width: 120 }),
+                block(COLORS.red, { width: 220 }),
+              ],
             },
           },
         ],
@@ -122,7 +157,9 @@ export default async () => {
       width: 1200,
       height: 630,
       embedFont: true,
-      fonts: await loadGoogleFonts(SITE.title + SITE.desc + SITE.website),
+      fonts: await loadGoogleFonts(
+        SITE.title + SITE.desc + SITE.author + hostname
+      ),
     }
   );
 };

--- a/src/utils/og-templates/site.js
+++ b/src/utils/og-templates/site.js
@@ -1,21 +1,7 @@
 import satori from "satori";
 import { SITE } from "@/config";
 import loadGoogleFonts from "../loadGoogleFont";
-
-const COLORS = {
-  cream: "#F4EFE6",
-  black: "#0A0A0A",
-  red: "#D5232A",
-  blue: "#1E4FA1",
-  yellow: "#F1C232",
-};
-
-const STROKE = 8;
-
-const block = (background, extra = {}) => ({
-  type: "div",
-  props: { style: { background, display: "flex", ...extra } },
-});
+import { COLORS, STROKE, block } from "./mondrian";
 
 export default async () => {
   const hostname = new URL(SITE.website).hostname;


### PR DESCRIPTION
## Summary

Per-post and site-level dynamic OG cards now render in the Mondrian/De Stijl identity established by the static `public/og.png` (PR #131), instead of AstroPaper's off-white-card default. Site shares now read as one design across the static fallback and the dynamic cards crawlers cache per URL. Shared palette + block factory live in `src/utils/og-templates/mondrian.js` so the two templates can't drift on the visual identity. Post pub date renders as RFC 3339 (`2024-01-03`) — unambiguous globally, sortable, narrowest format.

## Gotchas

- Tags omitted from the post card. Filed as #147 — the bottom-strip yellow cell is reserved for that follow-up. Tag count is unbounded so the cap and overflow strategy got their own scope.
- Static `public/og.png` shadows `src/pages/og.png.ts` at build time (Astro's static-file priority), so `dist/og.png` is the static asset. The dynamic site template still gets exercised — verified by temporarily moving the static aside and rebuilding. Issue scoped both templates explicitly so this stays.
- Font swap: `loadGoogleFont.ts` now loads IBM Plex Sans instead of IBM Plex Mono. Adjacent code change, but a monospace fights the De Stijl blocks visually and conflicts with the static card's sans-serif wordmark.
- No layout-helper extraction yet. #147 will reveal whether the post-only tag slot warrants a frame abstraction or stays as a per-template divergence.

## Verification

- `pnpm build` clean (`astro check && astro build && pagefind`); 43 pages.
- Spot-checked generated cards under `dist/posts/*/index.png` for short title (`Predefined color schemes`, 24 chars) and long title (`How to use Git Hooks to set Created and Modified Dates`, 54 chars) — both render with title prominent, no overflow, date and hostname properly spaced in bottom strip.
- Generated dynamic site card under `dist/og.png` (with static moved aside) renders title + description + author + hostname in the same Mondrian frame.
- Post-extraction rebuild byte-checked against pre-extraction output — identical.
- `pnpm lint` clean; `prettier --check` clean on touched files (two unrelated pre-existing format warnings on `package.json` / `pre-commit.yml` are out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)