### PR TITLE
Run the build on PRs, gate deploy on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -10,13 +11,13 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      # Cancel superseded PR runs; never cancel main so each commit's build completes.
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6
@@ -26,7 +27,11 @@ jobs:
 
   deploy:
     needs: build
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,14 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
       # Cancel superseded PR runs; never cancel main so each commit's build completes.
@@ -29,6 +26,10 @@ jobs:
     needs: build
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     concurrency:
       group: pages
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

PR checks now exercise `pnpm install` + `astro build` against the same `withastro/action` config that ships to Pages. Closes the gap that let #137 (pnpm v10 → v11) merge green and only fail post-merge on the deploy push (root cause + recovery in #151). Permissions move from workflow-level to job-level so the build job runs with `contents: read` only — `pages: write` / `id-token: write` are scoped to deploy.

## Gotchas

- `deploy` is gated by `if: (push || workflow_dispatch) && ref == refs/heads/main`, so PRs build but don't deploy. Manual `workflow_dispatch` against main still deploys.
- Concurrency moved to job level. Build uses a per-ref group and cancels superseded PR runs (matches `bats.yml`); deploy keeps the original `pages` group with `cancel-in-progress: false` so consecutive main deploys serialize — the GitHub Pages-recommended pattern.

## Verification

- New `build` check is firing on this PR alongside Bats / Lychee / Pre-commit — proves the trigger works.
- Diff is the trigger addition, the deploy `if:` guard, the concurrency relocation, and the per-job permissions split. Nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)