### PR TITLE
Surface up to 3 tags on per-post OG card

### DIFF
--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -11,6 +11,12 @@ const formatDate = (date, timezone) =>
     timeZone: timezone,
   }).format(date);
 
+const TAG_LIMIT = 3;
+const TAG_CHAR_LIMIT = 12;
+
+const truncate = tag =>
+  tag.length > TAG_CHAR_LIMIT ? tag.slice(0, TAG_CHAR_LIMIT - 1) + "…" : tag;
+
 export default async post => {
   const hostname = new URL(SITE.website).hostname;
   const pubDate = formatDate(
@@ -18,6 +24,7 @@ export default async post => {
     post.data.timezone ?? SITE.timezone
   );
   const titleSize = post.data.title.length > 60 ? 64 : 84;
+  const tags = post.data.tags.slice(0, TAG_LIMIT).map(truncate);
 
   return satori(
     {
@@ -106,7 +113,30 @@ export default async post => {
                 height: 132,
               },
               children: [
-                block(COLORS.yellow, { width: 96 }),
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      width: 200,
+                      background: COLORS.yellow,
+                      display: "flex",
+                      flexDirection: "column",
+                      justifyContent: "center",
+                      gap: 6,
+                      padding: "0 20px",
+                      fontSize: 22,
+                      color: COLORS.black,
+                      overflow: "hidden",
+                    },
+                    children: tags.map(tag => ({
+                      type: "div",
+                      props: {
+                        style: { whiteSpace: "nowrap" },
+                        children: `#${tag}`,
+                      },
+                    })),
+                  },
+                },
                 {
                   type: "div",
                   props: {
@@ -146,7 +176,9 @@ export default async post => {
       width: 1200,
       height: 630,
       embedFont: true,
-      fonts: await loadGoogleFonts(post.data.title + pubDate + hostname),
+      fonts: await loadGoogleFonts(
+        post.data.title + pubDate + hostname + tags.join("") + "#…"
+      ),
     }
   );
 };


### PR DESCRIPTION
## Summary

Per-post OG cards now carry the first 2-3 frontmatter tags in the bottom-strip yellow cell, so a Bluesky/LinkedIn preview tells a skimmer the topic before they click — useful when the title doesn't telegraph the area.

## Gotchas

- Bottom-strip yellow cell widened 96 → 200 to give 3 stacked tags room without truncating common tags like `configuration` to junk. Mirrors the top-strip yellow's 200 (#146 reserved this cell as the tag slot). Date+hostname cell shrinks accordingly with no overflow.
- Per-tag truncation at 12 chars (`color-schemes` → `color-schem…`) plus `whiteSpace: nowrap` so satori doesn't break the tag at internal hyphens. The slice cap (3) handles count overflow; the char cap handles width overflow — no further drop logic needed.
- Default `["others"]` tag renders without special-casing, per the issue scope.

## Verification

- `pnpm build` clean; 43 pages.
- Spot-checked rendered `dist/posts/*/index.png` across:
  - single short tag (`adding-new-posts-in-astropaper-theme`: `#docs`)
  - two-tag mix incl. truncation (`customizing-astropaper-theme-color-schemes`: `#color-schem…` + `#docs`)
  - two-tag short (`setting-dates-via-git-hooks`: `#docs` + `#FAQ`; `dynamic-og-image-generation-in-astropaper-blog-posts`: `#docs` + `#release`)
  - three-tag (`how-to-integrate-giscus-comments`: `#astro` + `#blog` + `#docs`)
- `pnpm lint` clean; `prettier --check` clean on the touched file.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)