### PR TITLE
Add /tag-suggest skill for frontmatter tag proposals

### DIFF
--- a/.claude/skills/tag-suggest/SKILL.md
+++ b/.claude/skills/tag-suggest/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tag-suggest
-description: Propose 2–3 frontmatter tags for a draft blog post. Scans existing tags across `src/data/blog/**/*.md`, prioritises existing matches, flags morphological near-duplicates, justifies any net-new tag. Read-only — never mutates the post. Use via `/tag-suggest <path>` or omit the path to default to the currently staged/modified post.
+description: Propose 2–3 frontmatter tags for a draft blog post. Scans existing tags across `src/data/blog/**/*.md`, prioritises existing matches, flags morphological near-duplicates, justifies any net-new tag. Proposes first; only writes to the file after explicit author confirmation. Use via `/tag-suggest <path>` or omit the path to default to the currently staged/modified post.
 ---
 
 # Tag-suggest
 
-Pipeline: **resolve target → enumerate corpus → propose → report**. Read-only. Author copies the recommendation into frontmatter; the skill never writes.
+Pipeline: **resolve target → enumerate corpus → propose → confirm → apply**. The proposal is always presented before any file write; the apply step only runs after the author confirms.
 
 ## 1. Resolve target
 
@@ -37,14 +37,14 @@ Read the target post — frontmatter + body. Then propose **2–3 tags** subject
 
 Upstream tutorial posts contribute tags like `docs`, `release`, `FAQ`, `configuration`, `color-schemes`. Treat them as part of the inventory — they're rendered on the live site — but don't propose them for user-authored content unless the post is genuinely about that topic.
 
-## 4. Report
+## 4. Report + confirm
 
-Output a chat-only report. Don't edit the file. Shape:
+Output a chat-only report. **Do not write to the file yet.** Shape:
 
 - **Target** — path + current `tags:` (if any).
 - **Existing tag inventory (top ~10)** — `tag (N)` per line. Surface enough to ground the proposal; the author can ask for the full list if needed.
 - **Proposed tags** — bullet list. For each: `tag-name` — short rationale (≤1 sentence). Mark existing matches as `existing, N posts`; mark net-new as `new` with the nearest inventory neighbour and why it doesn't fit.
-- **Copy this into frontmatter** — fenced YAML block ready to paste:
+- **Proposed frontmatter block** — fenced YAML showing what would be written:
 
   ```yaml
   tags:
@@ -53,10 +53,21 @@ Output a chat-only report. Don't edit the file. Shape:
     - tag-three
   ```
 
-End the report. Don't offer to edit the file; the rule of this skill is the author pastes.
+End with: **"Apply to `<path>`? [y/N]"** Wait for the author's response.
+
+## 5. Apply (on confirm)
+
+Only after an affirmative response (`y`, `yes`, `apply`, "go ahead", etc.):
+
+- Replace the post's existing `tags:` block in-place. Preserve frontmatter order and surrounding fields.
+- If no `tags:` block exists, insert one after `title:` (or after `pubDatetime:` if title is absent — pick the first field present in the order: `title`, `pubDatetime`, `author`).
+- Use list-form YAML (`tags:\n  - foo`) to match the repo convention.
+- Don't touch any other frontmatter field; don't reflow unrelated whitespace.
+
+On a non-affirmative or absent response, leave the file alone and end. Author can rerun later with edits to the proposal.
 
 ## Out of scope
 
 - Corpus-wide tag audit (single-occurrence singletons, all near-duplicate pairs, drift across the whole inventory). File separately if it earns its place once the corpus grows past ~10 user-authored posts.
-- Mutating the post. The author owns the frontmatter; the skill recommends.
 - Deterministic hygiene (lowercase enforcement, duplicate-within-post, naming style). Pre-commit hook territory; defer until drift is observable.
+- Editing the body. The skill mutates `tags:` only — never paragraphs, never other frontmatter fields.

--- a/.claude/skills/tag-suggest/SKILL.md
+++ b/.claude/skills/tag-suggest/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tag-suggest
+description: Propose 2–3 frontmatter tags for a draft blog post. Scans existing tags across `src/data/blog/**/*.md`, prioritises existing matches, flags morphological near-duplicates, justifies any net-new tag. Read-only — never mutates the post. Use via `/tag-suggest <path>` or omit the path to default to the currently staged/modified post.
+---
+
+# Tag-suggest
+
+Pipeline: **resolve target → enumerate corpus → propose → report**. Read-only. Author copies the recommendation into frontmatter; the skill never writes.
+
+## 1. Resolve target
+
+- Path argument given: use it.
+- No argument: pick the `.md` under `src/data/blog/` from `git status --porcelain` (staged or modified). If zero matches or more than one, ask.
+
+## 2. Enumerate corpus
+
+```bash
+find src/data/blog -name '*.md' -type f -exec awk '
+  /^tags:/ { in_tags=1; next }
+  in_tags && /^  - / { sub(/^  - /,""); print; next }
+  in_tags && /^[^ ]/ { in_tags=0 }
+' {} + | sort | uniq -c | sort -rn
+```
+
+Scan the full corpus including `_<engine>/` archives and `examples/`. AstroPaper's loader excludes `_`-prefixed *filenames*, not directory descendants, so archived posts still contribute tags to `/tags/<tag>` pages. Filtering would lose signal about which topics already cluster.
+
+Assumes list-form YAML (`tags:\n  - foo`). Inline `tags: [a, b]` is not used in this repo.
+
+## 3. Propose
+
+Read the target post — frontmatter + body. Then propose **2–3 tags** subject to:
+
+- **Existing matches win.** If `reading` covers the topic, propose `reading`. Don't coin `reads` or `reading-method`.
+- **Content topics only.** A tag answers "what is this post *about*?". Not category, era, format, draft state. See `feedback_tags_are_content_only.md`. Reject `archive`, `hakyll`, `2018`, `revisit`, `draft` — those signals live in directory structure (`_hakyll/`) or schema fields (`draft`, `featured`).
+- **Soft cap 3.** Drop a marginal tag rather than padding to fill the cap.
+- **Near-duplicate check.** Before proposing a net-new tag, scan the inventory for morphological neighbours: singular/plural (`book` vs `books`), gerund/noun (`reading` vs `reads`), hyphenation (`color-schemes` vs `colorschemes`), capitalisation (`Astro` vs `astro`). If a neighbour exists, justify why the new tag is meaningfully distinct or fold into the existing one.
+
+Upstream tutorial posts contribute tags like `docs`, `release`, `FAQ`, `configuration`, `color-schemes`. Treat them as part of the inventory — they're rendered on the live site — but don't propose them for user-authored content unless the post is genuinely about that topic.
+
+## 4. Report
+
+Output a chat-only report. Don't edit the file. Shape:
+
+- **Target** — path + current `tags:` (if any).
+- **Existing tag inventory (top ~10)** — `tag (N)` per line. Surface enough to ground the proposal; the author can ask for the full list if needed.
+- **Proposed tags** — bullet list. For each: `tag-name` — short rationale (≤1 sentence). Mark existing matches as `existing, N posts`; mark net-new as `new` with the nearest inventory neighbour and why it doesn't fit.
+- **Copy this into frontmatter** — fenced YAML block ready to paste:
+
+  ```yaml
+  tags:
+    - tag-one
+    - tag-two
+    - tag-three
+  ```
+
+End the report. Don't offer to edit the file; the rule of this skill is the author pastes.
+
+## Out of scope
+
+- Corpus-wide tag audit (single-occurrence singletons, all near-duplicate pairs, drift across the whole inventory). File separately if it earns its place once the corpus grows past ~10 user-authored posts.
+- Mutating the post. The author owns the frontmatter; the skill recommends.
+- Deterministic hygiene (lowercase enforcement, duplicate-within-post, naming style). Pre-commit hook territory; defer until drift is observable.

--- a/.claude/skills/tag-suggest/SKILL.md
+++ b/.claude/skills/tag-suggest/SKILL.md
@@ -15,16 +15,14 @@ Pipeline: **resolve target → enumerate corpus → propose → confirm → appl
 ## 2. Enumerate corpus
 
 ```bash
-find src/data/blog -name '*.md' -type f -exec awk '
-  /^tags:/ { in_tags=1; next }
-  in_tags && /^  - / { sub(/^  - /,""); print; next }
-  in_tags && /^[^ ]/ { in_tags=0 }
-' {} + | sort | uniq -c | sort -rn
+find src/data/blog -name '*.md' -type f \
+  | while read -r f; do yq --front-matter=extract '.tags[]' "$f" 2>/dev/null; done \
+  | sort | uniq -c | sort -rn
 ```
 
-Scan the full corpus including `_<engine>/` archives and `examples/`. AstroPaper's loader excludes `_`-prefixed *filenames*, not directory descendants, so archived posts still contribute tags to `/tags/<tag>` pages. Filtering would lose signal about which topics already cluster.
+`yq --front-matter=extract` reads only the YAML between the opening and closing `---` lines, so a `tags:` block appearing in the post body (e.g. inside a documentation code example) is correctly ignored. The query handles both list-form (`tags:\n  - foo`) and inline (`tags: [a, b]`) without case-splitting.
 
-Assumes list-form YAML (`tags:\n  - foo`). Inline `tags: [a, b]` is not used in this repo.
+Scan the full corpus including `_<engine>/` archives and `examples/`. AstroPaper's loader excludes `_`-prefixed *filenames*, not directory descendants, so archived posts still contribute tags to `/tags/<tag>` pages. Filtering would lose signal about which topics already cluster.
 
 ## 3. Propose
 
@@ -59,10 +57,11 @@ End with: **"Apply to `<path>`? [y/N]"** Wait for the author's response.
 
 Only after an affirmative response (`y`, `yes`, `apply`, "go ahead", etc.):
 
-- Replace the post's existing `tags:` block in-place. Preserve frontmatter order and surrounding fields.
-- If no `tags:` block exists, insert one after `title:` (or after `pubDatetime:` if title is absent — pick the first field present in the order: `title`, `pubDatetime`, `author`).
-- Use list-form YAML (`tags:\n  - foo`) to match the repo convention.
-- Don't touch any other frontmatter field; don't reflow unrelated whitespace.
+```bash
+yq --front-matter=process -i '.tags = ["tag-one", "tag-two", "tag-three"]' <path>
+```
+
+`yq --front-matter=process` rewrites only the frontmatter block, preserves key order, retains list-form output, and leaves the body untouched. If `tags:` is absent, yq appends a list-form block at the end of frontmatter. Quoted/escaped scalars in other fields (e.g. `description: "…\""`) are preserved verbatim.
 
 On a non-affirmative or absent response, leave the file alone and end. Author can rerun later with edits to the proposal.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,14 @@ highlights, and Reader archives into themes that might seed posts.
 Invoke via `/digest [Nd|Nw|Nm|Ny|last]`. Promising kernels file as
 issues with the `idea` template.
 
+## Tag-suggest skill
+
+`.claude/skills/tag-suggest/` proposes frontmatter tags for a draft
+post — scans the corpus's existing tag inventory, prioritises reuse
+over invention, flags morphological near-duplicates. Invoke via
+`/tag-suggest <path>` (defaults to the currently staged post).
+Read-only; the author pastes the recommendation in.
+
 ## Idea issues
 
 `.github/workflows/labels.yml` auto-applies the `idea` label to any

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ issues with the `idea` template.
 post — scans the corpus's existing tag inventory, prioritises reuse
 over invention, flags morphological near-duplicates. Invoke via
 `/tag-suggest <path>` (defaults to the currently staged post).
-Read-only; the author pastes the recommendation in.
+Proposes first, then applies to the file only after the author
+confirms.
 
 ## Idea issues
 


### PR DESCRIPTION
## Summary

`/tag-suggest <path>` now proposes 2–3 frontmatter tags grounded in the existing corpus inventory and, on confirmation, writes them in-place. Closes #156.

## Gotchas

- New env dep: `mikefarah/yq` v4+. Assumed on PATH; not pinned in-repo.
- Skill rejects `archive`/era/format tags per `feedback_tags_are_content_only.md`. #156's `archive` acceptance bullet predates that decision and is intentionally not honoured.

## Verification

- Ran `yq --front-matter=process -i` on a copy of `how-i-read-eight-years-on.md`: only the `tags:` block changed; key order, list-form, and escaped `description:` preserved.