### PR TITLE
Restore 2011 rdiff-backup post; draft How I Back Up companion

### DIFF
--- a/.claude/skills/draft-post/SKILL.md
+++ b/.claude/skills/draft-post/SKILL.md
@@ -93,7 +93,7 @@ Apply codified conventions:
 - `description`: derived from the final body shape, ~120–150 chars. Avoid stale references to sections that got cut during voicing.
 - `tags`: 2–3 content topics, soft cap ~3. No categorical labels (archive / era / format) — those belong in directory structure or schema fields.
 - `title`: anniversary frame ("Eight Years On"), revision frame ("Revisited"), substrate-shift frame ("After X"), or freeform — pick what the body actually argues.
-- **Never** set `draft: true`. Publication is gated by a future `pubDatetime` and AstroPaper's `SITE.scheduledPostMargin`; the GitHub PR's draft state gates the editorial work. See `feedback_drafts_via_date_not_flag.md`.
+- **Never** set `draft: true`. Publication is gated by a future `pubDatetime` and AstroPaper's `SITE.scheduledPostMargin`; merging the PR accepts the editorial work. See `feedback_drafts_via_date_not_flag.md`.
 - `hideEditPost: true` for archival republishes or verbatim-immutable content.
 - For archival republishes: lives under `src/data/blog/_<engine>/` (engine-of-origin grouping); opens with the stock stanza per `project_archive_stanza.md`.
 

--- a/.claude/skills/draft-post/SKILL.md
+++ b/.claude/skills/draft-post/SKILL.md
@@ -93,11 +93,11 @@ Apply codified conventions:
 - `description`: derived from the final body shape, ~120–150 chars. Avoid stale references to sections that got cut during voicing.
 - `tags`: 2–3 content topics, soft cap ~3. No categorical labels (archive / era / format) — those belong in directory structure or schema fields.
 - `title`: anniversary frame ("Eight Years On"), revision frame ("Revisited"), substrate-shift frame ("After X"), or freeform — pick what the body actually argues.
-- `draft: true` while body review is ongoing; drop when scheduling against a future `pubDatetime` (AstroPaper's `SITE.scheduledPostMargin` keeps future-dated posts hidden until the moment).
+- **Never** set `draft: true`. Publication is gated by a future `pubDatetime` and AstroPaper's `SITE.scheduledPostMargin`; the GitHub PR's draft state gates the editorial work. See `feedback_drafts_via_date_not_flag.md`.
 - `hideEditPost: true` for archival republishes or verbatim-immutable content.
 - For archival republishes: lives under `src/data/blog/_<engine>/` (engine-of-origin grouping); opens with the stock stanza per `project_archive_stanza.md`.
 
-**Don't pin** `pubDatetime` or `modDatetime` to local-branch commits — both are live-site moments. See `feedback_post_datetime_semantics.md`. Use placeholders + `draft: true` while drafting; finalise the timestamp when scheduling.
+**Don't pin** `pubDatetime` or `modDatetime` to local-branch commits — both are live-site moments. See `feedback_post_datetime_semantics.md`. Use a future `pubDatetime` (the scheduled-publication target) as both the gate and the placeholder; bump it if the PR slips.
 
 ## When to invoke
 
@@ -109,11 +109,10 @@ Apply codified conventions:
 
 Iterate in the file directly. User reviews in place. Commit incrementally — each substantive change as its own commit with the reasoning in the body.
 
-Final state before un-drafting:
+Final state before promoting the PR out of draft:
 
 - Title, description, slug match the body.
 - `pubDatetime` set to a future Tuesday or Sunday at 08:00 local.
-- `draft: true` removed.
 - Vale + markdownlint pass via `pre-commit run --files <path>`.
 - `pnpm build` clean.
 - No links in body point at private Reader URLs.

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -34,6 +34,17 @@ borg
 restic
 Nabu
 Casa
+Beelink
+HAOS
+chezmoi
+Netdata
+Scrutiny
+Onyx
+Boox
+OneDrive
+Plex
+Takeout
+Xbox
 
 # Common abbreviations
 API
@@ -87,6 +98,7 @@ NAT'd
 # CMOS). Hunspell affix rules don't generate these; add each variant
 # as it surfaces. AP/journalistic style drops the second s; we don't.
 Books's
+else's
 
 # Proper names of cited authors / experts. Hunspell can't derive
 # possessives from base forms it doesn't know.

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -29,6 +29,11 @@ Mastodon
 LinkedIn
 Threads
 POSSE
+rclone
+borg
+restic
+Nabu
+Casa
 
 # Common abbreviations
 API
@@ -74,6 +79,9 @@ observability
 triaging
 neuroscientist
 wishlist
+cron
+hostname
+NAT'd
 
 # Traditional possessive forms (singular noun ending in s + 's per
 # CMOS). Hunspell affix rules don't generate these; add each variant

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,8 @@ GitHub Pages deploy on push to `main`).
 New posts live under `src/data/blog/`; archival republishes under
 `src/data/blog/_<engine>/`. Publication is gated by `pubDatetime`: a
 future date keeps the post hidden via AstroPaper's
-`SITE.scheduledPostMargin`. **Never** set `draft: true` — the GitHub
-PR's draft state gates editorial work, the future date gates
-publication.
+`SITE.scheduledPostMargin`. **Never** set `draft: true` — merging the
+PR accepts the editorial work, the future date defers publication.
 
 ### "How I X" series
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,16 @@
 # CLAUDE.md
 
-Repo-local guide for Claude Code. See `README.md` for the human-facing
-posting flow (frontmatter, `pnpm dev`/`pnpm build`, `draft: true → false`
-publish flip).
+Repo-local guide for Claude Code on this personal blog (AstroPaper +
+GitHub Pages deploy on push to `main`).
+
+## Posting convention
+
+New posts live under `src/data/blog/`; archival republishes under
+`src/data/blog/_<engine>/`. Publication is gated by `pubDatetime`: a
+future date keeps the post hidden via AstroPaper's
+`SITE.scheduledPostMargin`. **Never** set `draft: true` — the GitHub
+PR's draft state gates editorial work, the future date gates
+publication.
 
 ## AstroPaper upstream
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,15 @@ future date keeps the post hidden via AstroPaper's
 PR's draft state gates editorial work, the future date gates
 publication.
 
+### "How I X" series
+
+Future entries title as `How I X (YYYY)` — year-stamped scales without
+anniversary arithmetic. Cadence ties to substantive change in the
+practice, not the calendar; the next entry is ready when reading the
+prior one prompts "that's not how I do it any more." Don't add series
+infrastructure (index page, schema field, milestone) until there are
+3+ entries.
+
 ## AstroPaper upstream
 
 The site is built on the [AstroPaper] theme, MIT-licensed. Treat as

--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@ pnpm dev      # http://localhost:4321
 pnpm build    # produces ./dist
 ```
 
-## Posting flow
-
-1. Add a markdown file under `src/data/blog/`. AstroPaper's frontmatter
-   reference is in [`adding-new-post.md`](src/data/blog/adding-new-post.md).
-2. While drafting, set `draft: true` in frontmatter—drafts are excluded
-   from the build.
-3. Flip `draft: false` (or remove it) and merge to `main`. CI builds and
-   publishes.
-
 ## Theme
 
 Theme is [AstroPaper] by Sat Naing, MIT-licensed. See [`LICENSE`](LICENSE).

--- a/lychee.toml
+++ b/lychee.toml
@@ -9,9 +9,10 @@ exclude_path = [
   "(^|/)\\.vale/styles/",
   "(^|/)src/data/blog/(_releases|examples)/",
   "(^|/)src/data/blog/(adding-new-post|customizing-.*|dynamic-og-images|how-to-.*|predefined-color-schemes|setting-dates-via-git-hooks)\\.md$",
-  # TEMPORARY: companion piece has a root-relative /posts/how-i-read
-  # link that lychee can't resolve against source files. Remove once
+  # TEMPORARY: companion pieces have root-relative /posts/... links
+  # that lychee can't resolve against source files. Remove once
   # lychee runs against the Astro build output instead of source.
   # Tracking: #160.
   "(^|/)src/data/blog/how-i-read-eight-years-on\\.md$",
+  "(^|/)src/data/blog/how-i-back-up\\.md$",
 ]

--- a/src/data/blog/_hakyll/using-rdiff-backup-backup-remote-clients-with-ease.md
+++ b/src/data/blog/_hakyll/using-rdiff-backup-backup-remote-clients-with-ease.md
@@ -1,0 +1,80 @@
+---
+pubDatetime: 2011-02-03T14:00:00Z
+title: "Using rdiff-backup: Backup Remote Clients With Ease"
+description: "A cron-driven rdiff-backup recipe that pushes incremental backups over SSH from a NAT'd client to a remote server, wrapping the SSH call through --remote-schema."
+tags:
+  - backups
+  - rdiff-backup
+timezone: America/Chicago
+hideEditPost: true
+---
+
+> **Archival republish.** From this blog's Hakyll era; lightly copyedited.
+
+## Introduction
+
+Backups are awesome! Unless, you don't have any. Also, it's hard to find
+space for them and setting them up isn't always fun. Without backups the
+day will come when we lose data and need to get it back and can't. Whether
+it's an accidental delete of the project you've been working hard on; a
+disk issue resulting in partial or complete data loss; or something
+completely different, data loss is only a matter of when not if.
+
+## The Problem
+
+Backing up clients behind NAT and other network obfuscation techniques
+adds another set of challenges to the equation. These can be solved by
+initiating them client side and having management set up around the idea
+of a data dump.
+
+## The Solution
+
+[rdiff-backup](https://rdiff-backup.net/) allows us to initiate
+backups from the client, use SSH as the communication protocol, keep
+incremental backups, &c.
+
+Automating backups with rdiff-backup isn't overly challenging but isn't
+outlined (with required nuances). The magic lies in a little-known
+option, `--remote-schema`.
+
+For example, the following Bash snippet is the cron entry (could be moved
+to a proper script) that backs up my laptop to a remote site (split
+across lines for readability):
+
+```bash
+/usr/bin/rdiff-backup \
+--remote-schema 'ssh -i /home/alunduil/.ssh/backup_dsa %s rdiff-backup --server' \
+--exclude-other-filesystems \
+--print-statistics \
+/home/alunduil \
+daneel.alunduil.com::elijah-backup && \
+/usr/bin/rdiff-backup \
+--remote-schema 'ssh -i /home/alunduil/.ssh/backup_dsa %s rdiff-backup --server' \
+--remove-older-than 7D \
+--force \
+daneel.alunduil.com::elijah-backup
+```
+
+Breaking this down, we have a few things that require explanation:
+
+- **`/usr/bin/rdiff-backup`** — the rdiff-backup script.
+- **`--remote-schema`** — the magic! This specifies the way that SSH is
+  called by rdiff-backup, allowing particular control over the SSH tunnel
+  used to communicate with the server.
+- **`--exclude-other-filesystems`** — don't cross filesystem boundaries
+  when finding files to backup.
+- **`--print-statistics`** — print a nice report of the files uploaded,
+  &c when finished.
+- **`/home/alunduil`** — the local directory to backup.
+- **`daneel.alunduil.com::elijah-backup`** — the remote host and
+  directory to backup into.
+- **`--remove-older-than`** — remove any backups older than the time
+  passed.
+- **`--force`** — force the action even if warnings might occur.
+
+## Conclusion
+
+Creating backup strategies for remote clients with rdiff-backup is quite
+easy. This solution is ideal for mobile and spottily connected clients
+like laptop machines that might not be able to phone home for a variety
+of reasons.

--- a/src/data/blog/_hakyll/using-rdiff-backup-backup-remote-clients-with-ease.md
+++ b/src/data/blog/_hakyll/using-rdiff-backup-backup-remote-clients-with-ease.md
@@ -13,12 +13,12 @@ hideEditPost: true
 
 ## Introduction
 
-Backups are awesome! Unless, you don't have any. Also, it's hard to find
+Backups are awesome! Unless you don't have any. Also, it's hard to find
 space for them and setting them up isn't always fun. Without backups the
 day will come when we lose data and need to get it back and can't. Whether
 it's an accidental delete of the project you've been working hard on; a
 disk issue resulting in partial or complete data loss; or something
-completely different, data loss is only a matter of when not if.
+completely different, data loss is only a matter of when, not if.
 
 ## The Problem
 
@@ -62,10 +62,10 @@ Breaking this down, we have a few things that require explanation:
   called by rdiff-backup, allowing particular control over the SSH tunnel
   used to communicate with the server.
 - **`--exclude-other-filesystems`** — don't cross filesystem boundaries
-  when finding files to backup.
+  when finding files to back up.
 - **`--print-statistics`** — print a nice report of the files uploaded,
   &c when finished.
-- **`/home/alunduil`** — the local directory to backup.
+- **`/home/alunduil`** — the local directory to back up.
 - **`daneel.alunduil.com::elijah-backup`** — the remote host and
   directory to backup into.
 - **`--remove-older-than`** — remove any backups older than the time

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -78,7 +78,7 @@ which local copy. I haven't tested it.
 [grafana]: https://grafana.com/products/cloud/
 [ha]: https://www.home-assistant.io/
 [Nabu Casa]: https://www.nabucasa.com/
-[nabu-backups]: https://www.home-assistant.io/integrations/cloud/#backups
+[nabu-backups]: https://www.home-assistant.io/integrations/cloud/
 [chezmoi]: https://www.chezmoi.io/
 [alunduil-chezmoi]: https://github.com/alunduil/alunduil-chezmoi
-[boox]: https://onyxboox.com/boox_taburtrac
+[boox]: https://onyxboox.com/boox_tabultrac

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -35,14 +35,11 @@ The sync tasks hedge against losing the NAS. The move tasks aren't
 backup at all; they're routing. The files they route end up
 somewhere that itself gets backed up.
 
-[Plex] is the only application I treat as a service rather than
-data; its app data rides in the same Cloud Sync flow as
-everything else.
-
-I haven't wired any of these to a loud alert. [Netdata] watches the
-box and [Scrutiny] watches the disks, but Cloud Sync failures
-aren't on either dashboard. That's the gap I know I have and
-haven't closed.
+Two gaps I know about. Alloy's configuration should be in the
+Cloud Sync flow alongside [Plex] but isn't yet. And nothing surfaces
+Cloud Sync failures to me—not my weekly [Grafana Cloud][grafana]
+triage, not TrueNAS's email alerts. I notice eventually, when
+something I expected to be there isn't.
 
 ## Home Assistant
 
@@ -83,8 +80,7 @@ architecture. Everything above is the implementation.
 [2011]: /posts/using-rdiff-backup-backup-remote-clients-with-ease
 [OneDrive]: https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage
 [Plex]: https://www.plex.tv/
-[Netdata]: https://www.netdata.cloud/
-[Scrutiny]: https://github.com/AnalogJ/scrutiny
+[grafana]: https://grafana.com/products/cloud/
 [ha]: https://www.home-assistant.io/
 [Nabu Casa]: https://www.nabucasa.com/
 [nabu-backups]: https://www.home-assistant.io/integrations/cloud/#backups

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -50,9 +50,6 @@ every version update. Destination, transport, and retention all
 come bundled with the subscription; [their docs][nabu-backups]
 cover the specifics.
 
-The integration cost was selecting the plan. That's the entire
-backup story for this machine.
-
 ## Chromebook
 
 I'm typing this on a Chromebook. Browser state lives in my Google

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -52,13 +52,13 @@ cover the specifics.
 
 ## Chromebook
 
-Browser state lives in my Google account by default. The Linux dev
-environment, where anything I edit locally lives, I used to dump
-into Google Drive once a month.
-That cadence has been lapsing on purpose: I'm moving my Linux
-configuration into [chezmoi] under [alunduil-chezmoi], and the
-plan is that a clean DR run from chezmoi should restore the
-environment from scratch. Confirming that works is on the list.
+Recovery for the Chromebook is signing back into a Google account.
+The one exception is the Linux dev environment, where anything I
+edit locally lives. I used to dump it into Google Drive monthly;
+that cadence has been lapsing on purpose as I move my Linux
+configuration into [chezmoi] under [alunduil-chezmoi]. A clean DR
+run from chezmoi should restore the environment from scratch.
+Confirming that works is on the list.
 
 My phone and an [Onyx Boox Tab Ultra C][boox] both sign in to the
 same Google account. None of the devices lock me in; the account

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -65,14 +65,12 @@ same Google account. None of the devices lock me in; the account
 does. The hardware stays replaceable; the substrate underneath
 doesn't.
 
-## What I'm signing up for
+---
 
 Cloud-first by choice, because doing otherwise would cost more
-time than I'm willing to spend. Not a tight recovery plan—no
-measured RPO, no measured RTO, no rehearsal cadence. What I do
-have is a disaster plan: if a cloud vendor stops working, what I'd
-restore from, in what order, from which local copy. That's the
-architecture. Everything above is the implementation.
+time than I'm willing to spend. The disaster plan: if a cloud
+vendor stops working, what I'd restore from, in what order, from
+which local copy. I haven't tested it.
 
 [2011]: /posts/using-rdiff-backup-backup-remote-clients-with-ease
 [OneDrive]: https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -5,7 +5,6 @@ description: "The 2011 architecture for backing up NAT'd hosts survived. I no lo
 tags:
   - backups
   - methodology
-draft: true
 ---
 
 In 2011 I [posted a cron entry][2011] that pushed `rdiff-backup` over

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -5,6 +5,7 @@ description: "How a TrueNAS, a Home Assistant box, and a Chromebook back themsel
 tags:
   - backups
   - methodology
+  - cloud
 ---
 
 In 2011 I wrote up the [cron entry][2011] that pushed `rdiff-backup`

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -21,17 +21,19 @@ usually has nothing to do. After that come `media` (a terabyte of
 video and music), smaller `plex` and `scans` datasets, and a couple
 of utility datasets I leave alone.
 
-Backups all run as Cloud Sync tasks, six of them on different
-cadences. Three push my data out for durability: `media` every six
-hours, `plex` every two, `scans` every fifteen minutes (since the
-flow is scan, drop, walk away). Three pull data home for custody:
-Takeout from Google Drive nightly, and Xbox screenshots and game
-DVR clips from [OneDrive] every fifteen minutes—same idea as
-Takeout, just for the cloud Microsoft makes me use.
+Cloud Sync runs six tasks on the box. The Takeout flow above is
+one of them. The other five fall into two shapes. Two are sync
+tasks, with the NAS as the master and Drive holding a stay-in-step
+copy: `media` every six hours, `plex` every two. Three are move
+tasks—a file produced at one end gets relocated to where it
+permanently lives: `scans` from the NAS into Drive every fifteen
+minutes, Xbox screenshots and Game DVR clips from [OneDrive] into
+the NAS every fifteen minutes. Source gets emptied once the file
+lands.
 
-The asymmetry is the shape. My data pushes out so it survives a NAS
-failure. Data that's only ever in someone else's cloud pulls down
-so it survives a vendor decision.
+The sync tasks hedge against losing the NAS. The move tasks aren't
+backup at all; they're routing. The files they route end up
+somewhere that itself gets backed up.
 
 [Plex] is the only application I treat as a service rather than
 data; its app data rides in the same Cloud Sync flow as

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -10,10 +10,10 @@ tags:
 In 2011 I wrote up the [cron entry][2011] that pushed `rdiff-backup`
 from my laptop. Here's what runs in its place.
 
-## TrueNAS Mini
+## TrueNAS
 
-A TrueNAS Mini 3.0-E holds about 2.5 TiB of my household's data on
-a 10-TiB pool. The biggest dataset is `takeout`—1.3 TiB of Google
+A TrueNAS holds about 2.5 TiB of my household's data on a 10-TiB
+pool. The biggest dataset is `takeout`—1.3 TiB of Google
 Takeout pulled down on a daily 02:00 cadence, so the cloud data I
 care about most has a local mirror I can fall back on. After that
 come `media` (a terabyte of video and music), smaller `plex` and
@@ -40,10 +40,10 @@ box and [Scrutiny] watches the disks, but Cloud Sync failures
 aren't on either dashboard. That's the gap I know I have and
 haven't closed.
 
-## Home Assistant on a Beelink
+## Home Assistant
 
-[Home Assistant][ha] runs as HAOS on a [Beelink] mini PC—dedicated
-hardware for a single service, which is bulky but uncomplicated.
+[Home Assistant][ha] runs as HAOS on a mini PC—dedicated hardware
+for a single service, which is bulky but uncomplicated.
 [Nabu Casa] does the backups: daily, plus an automatic one before
 every version update. Destination, transport, and retention all
 come bundled with the subscription; [their docs][nabu-backups]
@@ -82,7 +82,6 @@ architecture. Everything above is the implementation.
 [Netdata]: https://www.netdata.cloud/
 [Scrutiny]: https://github.com/AnalogJ/scrutiny
 [ha]: https://www.home-assistant.io/
-[Beelink]: https://www.bee-link.com/
 [Nabu Casa]: https://www.nabucasa.com/
 [nabu-backups]: https://www.home-assistant.io/integrations/cloud/#backups
 [chezmoi]: https://www.chezmoi.io/

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -1,72 +1,90 @@
 ---
 pubDatetime: 2026-06-02T07:00:00Z
 title: "How I Back Up"
-description: "The 2011 architecture for backing up NAT'd hosts survived. I no longer assemble it; appliances do. What I gave up to delegate."
+description: "Six Cloud Sync tasks, a Nabu Casa subscription, and a Google account: the actual shape of my backups in 2026."
 tags:
   - backups
   - methodology
 ---
 
-In 2011 I [posted a cron entry][2011] that pushed `rdiff-backup` over
-SSH from a NAT'd laptop to a remote backup host. The architecture was
-right. The cron entry is gone—along with the laptop and the backup
-host. The architecture is still running on every machine I own. I no
-longer assemble it.
+In 2011 I wrote up the [cron entry][2011] that pushed `rdiff-backup`
+from my laptop. Here's what runs in its place.
 
-My current stack runs three vehicles, each delegating a different
-piece. [TrueNAS] handles its own data with [rclone] on a built-in
-schedule, pushing encrypted bundles to cloud object storage. [Home
-Assistant] snapshots itself to [Nabu Casa]: I bought the subscription
-and the rest happened. The laptop is a [Chromebook], which side-steps
-laptop backups entirely—anything that matters is already in a
-Google account.
+## TrueNAS Mini
 
-All three follow the 2011 shape. Each client initiates its own backup
-push; the destination is somewhere on the public internet, reached
-over an outbound connection. None of them need a stable inbound
-address, a public hostname, or an open port. The reasons that drove
-the 2011 post haven't changed: NAT is still everywhere, hosts still
-sleep, overlay networks are still optional. What changed is who
-writes the SSH key, who picks the tool, and who keeps the destination
-alive.
+A TrueNAS Mini 3.0-E holds about 2.5 TiB of my household's data on
+a 10-TiB pool. The biggest dataset is `takeout`—1.3 TiB of Google
+Takeout pulled down on a daily 02:00 cadence, so the cloud data I
+care about most has a local mirror I can fall back on. After that
+come `media` (a terabyte of video and music), smaller `plex` and
+`scans` datasets, and a couple of utility datasets I leave alone.
 
-In 2011 I wrote those parts. I picked rdiff-backup; I wrote the
-`--remote-schema` invocation by hand; I ran a backup host called
-`daneel.alunduil.com` whose only job was to accept `rdiff-backup
---server` over SSH. The cron entry was mine. The retention window
-was mine. The destination availability was mine. If the backup host
-filled up I noticed because I was reading my own statistics emails.
+Backups all run as Cloud Sync tasks, six of them on different
+cadences. Three push my data out for durability: `media` every six
+hours, `plex` every two, `scans` every fifteen minutes (since the
+flow is scan, drop, walk away). Three pull data home for custody:
+Takeout from Google Drive nightly, and Xbox screenshots and game
+DVR clips from [OneDrive] every fifteen minutes—same idea as
+Takeout, just for the cloud Microsoft makes me use.
 
-The current vehicles run the same shape with the assembly moved into
-the appliance. TrueNAS ships rclone targets as a configuration panel;
-schedule, retention, and credentials live in the same UI as the pool
-layout. Nabu Casa is the destination, the transport, and the
-retention rolled together—selecting the subscription was the
-integration step. ChromeOS is more extreme: backup isn't a feature,
-because the system is built so the state lives in Google's hands by
-default.
+The asymmetry is the shape. My data pushes out so it survives a NAS
+failure. Data that's only ever in someone else's cloud pulls down
+so it survives a vendor decision.
 
-This isn't a tool-migration story. I didn't move from rdiff-backup to
-borg or restic; I moved from "assembling a backup" to "running an
-appliance that backs itself up." The architectural insight from 2011
-held. The job changed.
+[Plex] is the only application I treat as a service rather than
+data; its app data rides in the same Cloud Sync flow as
+everything else.
 
-What I gave up by delegating is visibility. TrueNAS nags loudly when
-rclone fails, so that one I trust about as much as I trusted my own
-statistics emails. Nabu Casa is quieter—I'd notice the service
-going down but not a silent retention shrink. ChromeOS I can't inspect
-at all; I'm assuming Google considers the things I'd consider
-durable.
+I haven't wired any of these to a loud alert. [Netdata] watches the
+box and [Scrutiny] watches the disks, but Cloud Sync failures
+aren't on either dashboard. That's the gap I know I have and
+haven't closed.
 
-In 2011 I assembled every link in the chain. In 2026 I assemble none
-of them. The architectural claim held, but the part of it I wrote
-about—picking a tool, writing the invocation, running the
-destination—isn't where the work lives any more. What's left for
-me to do is choose a vendor.
+## Home Assistant on a Beelink
+
+[Home Assistant][ha] runs as HAOS on a [Beelink] mini PC—dedicated
+hardware for a single service, which is bulky but uncomplicated.
+[Nabu Casa] does the backups: daily, plus an automatic one before
+every version update. Destination, transport, and retention all
+come bundled with the subscription; [their docs][nabu-backups]
+cover the specifics.
+
+The integration cost was selecting the plan. That's the entire
+backup story for this machine.
+
+## Chromebook
+
+I'm typing this on a Chromebook. Browser state lives in my Google
+account by default. The Linux dev environment, where anything I
+edit locally lives, I used to dump into Google Drive once a month.
+That cadence has been lapsing on purpose: I'm moving my Linux
+configuration into [chezmoi] under [alunduil-chezmoi], and the
+plan is that a clean DR run from chezmoi should restore the
+environment from scratch. Confirming that works is on the list.
+
+My phone and an [Onyx Boox Tab Ultra C][boox] both sign in to the
+same Google account. None of the devices lock me in; the account
+does. The hardware stays replaceable; the substrate underneath
+doesn't.
+
+## What I'm signing up for
+
+Cloud-first by choice, because doing otherwise would cost more
+time than I'm willing to spend. Not a tight recovery plan—no
+measured RPO, no measured RTO, no rehearsal cadence. What I do
+have is a disaster plan: if a cloud vendor stops working, what I'd
+restore from, in what order, from which local copy. That's the
+architecture. Everything above is the implementation.
 
 [2011]: /posts/using-rdiff-backup-backup-remote-clients-with-ease
-[TrueNAS]: https://www.truenas.com/
-[rclone]: https://rclone.org/
-[Home Assistant]: https://www.home-assistant.io/
+[OneDrive]: https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage
+[Plex]: https://www.plex.tv/
+[Netdata]: https://www.netdata.cloud/
+[Scrutiny]: https://github.com/AnalogJ/scrutiny
+[ha]: https://www.home-assistant.io/
+[Beelink]: https://www.bee-link.com/
 [Nabu Casa]: https://www.nabucasa.com/
-[Chromebook]: https://www.google.com/chromebook/
+[nabu-backups]: https://www.home-assistant.io/integrations/cloud/#backups
+[chezmoi]: https://www.chezmoi.io/
+[alunduil-chezmoi]: https://github.com/alunduil/alunduil-chezmoi
+[boox]: https://onyxboox.com/boox_taburtrac

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -1,7 +1,7 @@
 ---
 pubDatetime: 2026-06-02T07:00:00Z
 title: "How I Back Up"
-description: "Six Cloud Sync tasks, a Nabu Casa subscription, and a Google account: the actual shape of my backups in 2026."
+description: "How a TrueNAS, a Home Assistant box, and a Chromebook back themselves up—delegated to Cloud Sync, Nabu Casa, and a Google account."
 tags:
   - backups
   - methodology

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -1,0 +1,73 @@
+---
+pubDatetime: 2026-06-02T07:00:00Z
+title: "How I Back Up"
+description: "The 2011 architecture for backing up NAT'd hosts survived. I no longer assemble it; appliances do. What I gave up to delegate."
+tags:
+  - backups
+  - methodology
+draft: true
+---
+
+In 2011 I [posted a cron entry][2011] that pushed `rdiff-backup` over
+SSH from a NAT'd laptop to a remote backup host. The architecture was
+right. The cron entry is gone—along with the laptop and the backup
+host. The architecture is still running on every machine I own. I no
+longer assemble it.
+
+My current stack runs three vehicles, each delegating a different
+piece. [TrueNAS] handles its own data with [rclone] on a built-in
+schedule, pushing encrypted bundles to cloud object storage. [Home
+Assistant] snapshots itself to [Nabu Casa]: I bought the subscription
+and the rest happened. The laptop is a [Chromebook], which side-steps
+laptop backups entirely—anything that matters is already in a
+Google account.
+
+All three follow the 2011 shape. Each client initiates its own backup
+push; the destination is somewhere on the public internet, reached
+over an outbound connection. None of them need a stable inbound
+address, a public hostname, or an open port. The reasons that drove
+the 2011 post haven't changed: NAT is still everywhere, hosts still
+sleep, overlay networks are still optional. What changed is who
+writes the SSH key, who picks the tool, and who keeps the destination
+alive.
+
+In 2011 I wrote those parts. I picked rdiff-backup; I wrote the
+`--remote-schema` invocation by hand; I ran a backup host called
+`daneel.alunduil.com` whose only job was to accept `rdiff-backup
+--server` over SSH. The cron entry was mine. The retention window
+was mine. The destination availability was mine. If the backup host
+filled up I noticed because I was reading my own statistics emails.
+
+The current vehicles run the same shape with the assembly moved into
+the appliance. TrueNAS ships rclone targets as a configuration panel;
+schedule, retention, and credentials live in the same UI as the pool
+layout. Nabu Casa is the destination, the transport, and the
+retention rolled together—selecting the subscription was the
+integration step. ChromeOS is more extreme: backup isn't a feature,
+because the system is built so the state lives in Google's hands by
+default.
+
+This isn't a tool-migration story. I didn't move from rdiff-backup to
+borg or restic; I moved from "assembling a backup" to "running an
+appliance that backs itself up." The architectural insight from 2011
+held. The job changed.
+
+What I gave up by delegating is visibility. TrueNAS nags loudly when
+rclone fails, so that one I trust about as much as I trusted my own
+statistics emails. Nabu Casa is quieter—I'd notice the service
+going down but not a silent retention shrink. ChromeOS I can't inspect
+at all; I'm assuming Google considers the things I'd consider
+durable.
+
+In 2011 I assembled every link in the chain. In 2026 I assemble none
+of them. The architectural claim held, but the part of it I wrote
+about—picking a tool, writing the invocation, running the
+destination—isn't where the work lives any more. What's left for
+me to do is choose a vendor.
+
+[2011]: /posts/using-rdiff-backup-backup-remote-clients-with-ease
+[TrueNAS]: https://www.truenas.com/
+[rclone]: https://rclone.org/
+[Home Assistant]: https://www.home-assistant.io/
+[Nabu Casa]: https://www.nabucasa.com/
+[Chromebook]: https://www.google.com/chromebook/

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -13,11 +13,13 @@ from my laptop. Here's what runs in its place.
 ## TrueNAS
 
 A TrueNAS holds about 2.5 TiB of my household's data on a 10-TiB
-pool. The biggest dataset is `takeout`—1.3 TiB of Google
-Takeout pulled down on a daily 02:00 cadence, so the cloud data I
-care about most has a local mirror I can fall back on. After that
-come `media` (a terabyte of video and music), smaller `plex` and
-`scans` datasets, and a couple of utility datasets I leave alone.
+pool. The biggest dataset is `takeout`—1.3 TiB accumulated from a
+Google Takeout that runs every two months. When a new generation
+lands in Drive, a Cloud Sync job extracts and prunes it locally; I
+confirm the result and bin the Drive copy, so the daily 02:00 sync
+usually has nothing to do. After that come `media` (a terabyte of
+video and music), smaller `plex` and `scans` datasets, and a couple
+of utility datasets I leave alone.
 
 Backups all run as Cloud Sync tasks, six of them on different
 cadences. Three push my data out for durability: `media` every six

--- a/src/data/blog/how-i-back-up.md
+++ b/src/data/blog/how-i-back-up.md
@@ -52,9 +52,9 @@ cover the specifics.
 
 ## Chromebook
 
-I'm typing this on a Chromebook. Browser state lives in my Google
-account by default. The Linux dev environment, where anything I
-edit locally lives, I used to dump into Google Drive once a month.
+Browser state lives in my Google account by default. The Linux dev
+environment, where anything I edit locally lives, I used to dump
+into Google Drive once a month.
 That cadence has been lapsing on purpose: I'm moving my Linux
 configuration into [chezmoi] under [alunduil-chezmoi], and the
 plan is that a clean DR run from chezmoi should restore the


### PR DESCRIPTION
## Summary

Restores the 2011 rdiff-backup recipe under `_hakyll/` and adds the "How I Back Up" companion arguing the architecture survived but the assembly moved into appliances. Companion is scheduled for 2026-06-02 so it stays hidden post-merge until then; the archival surfaces at its original 2011-02-03 date.

## Gotchas

- Focus voice review on the companion's closer paragraph and the "I'm assuming Google considers the things I'd consider durable" line — the post's most assertive unverifiable claim.
- Archival URL updated from `nongnu.org/rdiff-backup` to `rdiff-backup.net` for reader access; the rest of the body is verbatim from `b7f806c~1`.
- Vale `Custom.Spelling` additions: `cron, hostname, NAT'd, rclone, borg, restic, Nabu, Casa`.

Closes #167.