### PR TITLE
Carry rel="me" on the GitHub social link

### DIFF
--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -10,6 +10,7 @@ import LinkButton from "./LinkButton.astro";
         href={social.href}
         class="p-2 hover:rotate-6 sm:p-1"
         title={social.linkTitle}
+        rel={social.rel}
       >
         <social.icon class="inline-block size-6 scale-125 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent sm:scale-110" />
         <span class="sr-only">{social.linkTitle}</span>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ interface Social {
   href: string;
   linkTitle: string;
   icon: (_props: Props) => Element;
+  rel?: string;
 }
 
 export const SOCIALS: Social[] = [
@@ -18,6 +19,7 @@ export const SOCIALS: Social[] = [
     href: "https://github.com/alunduil",
     linkTitle: `${SITE.author} on GitHub`,
     icon: IconGitHub,
+    rel: "me",
   },
   {
     name: "LinkedIn",


### PR DESCRIPTION
A `rel="me"` link from the homepage to the GitHub profile now lets IndieAuth verifiers complete the homepage → GitHub → homepage loop and confirm ownership of `blog.alunduil.com`.

The footer GitHub anchor previously rendered with no `rel` attribute, so a verifier fetching the homepage had no edge to follow. This adds an optional `rel` field to the `Social` interface, sets `rel="me"` on the GitHub entry, and passes it through `Socials.astro` to `LinkButton` (which already spreads arbitrary anchor attributes).

## Verification

Ran `pnpm astro build` and confirmed the rendered footer anchor carries the attribute: `<a href="https://github.com/alunduil" title="Alex Brandt on GitHub" rel="me" ...>`. Other profiles (LinkedIn, Bluesky, Mail) render without `rel`.

The remaining acceptance criteria — the reciprocal Website field on github.com/alunduil and an end-to-end IndieAuth resolve — are manual ops tracked on #148.

Closes #185