### PR TITLE
digest: fold Notion Media Log completions into the window

### DIFF
--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -43,15 +43,15 @@ Fetch Readwise + Reader + Notion Media Log for the same window via MCP, using `w
 
 - `readwise_list_highlights` — `highlighted_at_gt=<since>T00:00:00Z`, `page_size=100`, `response_fields=["text","note","url","highlighted_at","book_title","book_author"]`.
 - `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = engaged-with.
-- **Notion Media Log** — two lightweight tracker data sources the author maintains by hand (`Title` / `Status` / `Finished`):
+- **Notion Media Log** — two trackers the author maintains, schema `Title` / `Status` / `Finished` / `Added` (`Added` = auto-stamped creation date). Both grow unbounded, so never trust a semantic sweep to enumerate them — drive off `Added`.
   - Reading (books): `collection://886930b5-cd2e-4528-afe3-0bb6eb1bb8e1`
   - Playing (games): `collection://a37ceaff-e104-4298-b117-aa6ca386a0e6`
 
-  No Notion tool filters on a property's date, so query then post-filter. Per source: `notion-search` with `data_source_url=<collection>`, a domain `query` (`"book"` / `"video game"`), `page_size=25`, `max_highlight_length=0`. Search returns each row's title, url, and last-edited `timestamp` — **not** its properties. Keep rows with `timestamp >= <since>`, then `notion-fetch` each kept row by `id` to read `Status` + `Finished`. Classify:
-  - `Status = Finished` **and** `Finished` in `[since, now]` → **completion**: a review/commentary kernel (almost always `[short]` — see §4).
-  - `Status = Active` touched in-window → light "currently reading/playing" context. Not a kernel alone, but colors adjacent themes (e.g. a game whose mechanics echo a work post).
+  Per source, `notion-search` with `data_source_url=<collection>`, `query` a domain term (`"book"` / `"video game"`), `max_highlight_length=0`:
+  - **Started**: pass `filters.created_date_range={start_date: <since>}` — a server-side filter on `Added`, so it returns exactly the rows added in-window at any table size. `notion-fetch` each to read `Status`. → "started reading/playing this week" context.
+  - **Finished**: this MCP exposes **no** filter on the `Finished` property (`created_date_range` keys off `Added`, not `Finished`), so a completion on a row added in an earlier window can't be enumerated server-side. Best-effort: search with `query="finished"`, `page_size=25`, `notion-fetch` the candidates, keep `Status = Finished` with `Finished` in `[since, now]`. Reliable while lifetime finishes stay ≲25; past that a recent finish on an old row may fall outside the top-25 — say so in the digest rather than imply the sweep is exhaustive. Robust finished-at-scale needs Notion's native data-source query, not exposed here.
 
-  Low-volume tracker, so a `page_size=25` semantic sweep effectively enumerates each source; if either ever exceeds that, narrow the query or note possible misses.
+  Classify: a finish → **completion** kernel (review/commentary, almost always `[short]` — see §4). A start or `Status = Active` → light "currently reading/playing" context; not a kernel alone, but colors adjacent themes (e.g. a game whose mechanics echo a work post).
 
 If a source's MCP is unavailable, note which (e.g. "Notion Media Log unavailable") and continue with the rest.
 

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: digest
-description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, and Reader archives — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`); defaults to `7d` when no cadence is given. Output is chat-only, thematically clustered. Promising kernels → `gh issue create --label idea`.
+description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, Reader archives, and Notion Media Log completions (books/games finished) — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`); defaults to `7d` when no cadence is given. Output is chat-only, thematically clustered. Promising kernels → `gh issue create --label idea`.
 ---
 
 # Digest
@@ -39,17 +39,26 @@ JSON shape:
 
 ## 2. Analyze data (Claude pre-synthesis)
 
-Fetch Readwise + Reader for the same window via MCP, using `window.since` (append `T00:00:00Z`):
+Fetch Readwise + Reader + Notion Media Log for the same window via MCP, using `window.since` (append `T00:00:00Z`):
 
 - `readwise_list_highlights` — `highlighted_at_gt=<since>T00:00:00Z`, `page_size=100`, `response_fields=["text","note","url","highlighted_at","book_title","book_author"]`.
 - `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = engaged-with.
+- **Notion Media Log** — two lightweight tracker data sources the author maintains by hand (`Title` / `Status` / `Finished`):
+  - Reading (books): `collection://886930b5-cd2e-4528-afe3-0bb6eb1bb8e1`
+  - Playing (games): `collection://a37ceaff-e104-4298-b117-aa6ca386a0e6`
 
-If MCP unavailable, note "Readwise/Reader unavailable — GitHub-only digest" and continue.
+  No Notion tool filters on a property's date, so query then post-filter. Per source: `notion-search` with `data_source_url=<collection>`, a domain `query` (`"book"` / `"video game"`), `page_size=25`, `max_highlight_length=0`. Search returns each row's title, url, and last-edited `timestamp` — **not** its properties. Keep rows with `timestamp >= <since>`, then `notion-fetch` each kept row by `id` to read `Status` + `Finished`. Classify:
+  - `Status = Finished` **and** `Finished` in `[since, now]` → **completion**: a review/commentary kernel (almost always `[short]` — see §4).
+  - `Status = Active` touched in-window → light "currently reading/playing" context. Not a kernel alone, but colors adjacent themes (e.g. a game whose mechanics echo a work post).
+
+  Low-volume tracker, so a `page_size=25` semantic sweep effectively enumerates each source; if either ever exceeds that, narrow the query or note possible misses.
+
+If a source's MCP is unavailable, note which (e.g. "Notion Media Log unavailable") and continue with the rest.
 
 Mechanical patterns to extract before synthesis:
 
 - **Cross-source links**: archived Reader docs whose `url` matches a Readwise highlight → tag `has_highlights = true`. A highlight is a stronger engagement signal than archive alone.
-- **Completion arcs**: issues that appear in both `issues_opened` and `issues_closed` within the window. Narrative-ready ("started and finished this week").
+- **Completion arcs**: issues that appear in both `issues_opened` and `issues_closed` within the window, plus Media Log rows that reached `Status = Finished` in-window. Narrative-ready ("started and finished this week"; "finished this book/game — worth a review").
 - **Cross-project signals**: use `repos[].days_active` to spot repos with simultaneous activity bursts. Same kind of work hitting multiple repos on the same days is often a single underlying decision worth surfacing.
 - **Truncation**: if `window.truncated` is non-empty (excluding `commits`-only — squash-dedup destroys most raw items so commits-only truncation is usually noise), surface as a warning above the themed clusters.
 
@@ -69,14 +78,14 @@ Score each theme by signal-of-engagement-with-the-topic, present themes in desce
 
 - **Source breadth**: how many of {commits, PRs, issues_opened, issues_closed, comments, highlights, archives} contribute. Theme spanning 4+ sources beats theme drawn from one.
 - **Cross-source resonance**: theme has both a GitHub item AND a Readwise highlight on the same topic. External validation. Heavy weight.
-- **Completion arc presence**: theme contains an opened+closed issue or merged PR-with-explicit-Closes. Narrative-ready, easier to write.
+- **Completion arc presence**: theme contains an opened+closed issue, a merged PR-with-explicit-Closes, or a finished book/game. Narrative-ready, easier to write.
 - **Time span**: spans the whole window > single-day burst (sustained interest > momentary distraction).
 - **Cross-project**: same theme across multiple repos = pattern at a higher altitude, often the post-worthy angle.
 - **Volume**: tiebreaker only. More items ≠ inherently more interesting.
 
 After scoring, tag each theme **short** or **long** by shape (independent of score):
 
-- **short** — single idea worth amplifying. External quote/highlight + a paragraph of own commentary. No narrative arc, no walk-through. Themes dominated by one strong cross-source link with little code activity usually land here.
+- **short** — single idea worth amplifying. External quote/highlight + a paragraph of own commentary. No narrative arc, no walk-through. Themes dominated by one strong cross-source link with little code activity usually land here, as do most finished-book/game reviews.
 - **long** — multi-step narrative, how-to, tutorial, or explanation that names a pattern with a worked example. Themes with completion arcs, cross-project sweeps, or pipeline/architecture decisions usually land here.
 
 A theme can warrant both — a short signal-boost now and a long synthesis later. Say so.

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: digest
-description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, Reader archives, and Notion Media Log completions (books/games finished) — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`); defaults to `7d` when no cadence is given. Output is chat-only, thematically clustered. Promising kernels → `gh issue create --label idea`.
+description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, and Reader archives, plus an interactive Notion Media Log check-in (prompts for finished/started books & games and records the status changes) — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`); defaults to `7d` when no cadence is given. Output is thematically clustered in chat; the only side effects are Media Log status updates you confirm and idea issues on request. Promising kernels → `gh issue create --label idea`.
 ---
 
 # Digest
 
-Pipeline: **collect → analyze data → synthesize themes → analyze themes → present**. Each stage has a different owner; don't smear them.
+Pipeline: **collect → analyze data (incl. Media Log check-in) → synthesize themes → analyze themes → present**. Each stage has a different owner; don't smear them. The Media Log check-in is the one interactive, write-back step — everything else is read-only.
 
 ## 1. Collect (script)
 
@@ -39,21 +39,28 @@ JSON shape:
 
 ## 2. Analyze data (Claude pre-synthesis)
 
-Fetch Readwise + Reader + Notion Media Log for the same window via MCP, using `window.since` (append `T00:00:00Z`):
+Fetch Readwise + Reader for the same window via MCP (using `window.since`, append `T00:00:00Z`), then run the Media Log check-in:
 
 - `readwise_list_highlights` — `highlighted_at_gt=<since>T00:00:00Z`, `page_size=100`, `response_fields=["text","note","url","highlighted_at","book_title","book_author"]`.
 - `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = engaged-with.
-- **Notion Media Log** — two trackers the author maintains, schema `Title` / `Status` / `Finished` / `Added` (`Added` = auto-stamped creation date). Both grow unbounded, so never trust a semantic sweep to enumerate them — drive off `Added`.
-  - Reading (books): `collection://886930b5-cd2e-4528-afe3-0bb6eb1bb8e1`
-  - Playing (games): `collection://a37ceaff-e104-4298-b117-aa6ca386a0e6`
 
-  Per source, `notion-search` with `data_source_url=<collection>`, `query` a domain term (`"book"` / `"video game"`), `max_highlight_length=0`:
-  - **Started**: pass `filters.created_date_range={start_date: <since>}` — a server-side filter on `Added`, so it returns exactly the rows added in-window at any table size. `notion-fetch` each to read `Status`. → "started reading/playing this week" context.
-  - **Finished**: this MCP exposes **no** filter on the `Finished` property (`created_date_range` keys off `Added`, not `Finished`), so a completion on a row added in an earlier window can't be enumerated server-side. Best-effort: search with `query="finished"`, `page_size=25`, `notion-fetch` the candidates, keep `Status = Finished` with `Finished` in `[since, now]`. Reliable while lifetime finishes stay ≲25; past that a recent finish on an old row may fall outside the top-25 — say so in the digest rather than imply the sweep is exhaustive. Robust finished-at-scale needs Notion's native data-source query, not exposed here.
+**Notion Media Log check-in** — the one place the digest *writes*. Two trackers, schema `Title` / `Status` / `Finished` / `Added` (`Added` auto-stamps creation):
 
-  Classify: a finish → **completion** kernel (review/commentary, almost always `[short]` — see §4). A start or `Status = Active` → light "currently reading/playing" context; not a kernel alone, but colors adjacent themes (e.g. a game whose mechanics echo a work post).
+- Reading (books): `collection://886930b5-cd2e-4528-afe3-0bb6eb1bb8e1`
+- Playing (games): `collection://a37ceaff-e104-4298-b117-aa6ca386a0e6`
 
-If a source's MCP is unavailable, note which (e.g. "Notion Media Log unavailable") and continue with the rest.
+Don't try to *detect* completions by querying — **ask the author**; that's the completion edge, and it sidesteps any enumerate-at-scale gap, so the trackers can grow unbounded. Before synthesis:
+
+1. **Surface Active context** (best-effort, to prime the prompt): per source, `notion-search` `data_source_url=<collection>`, `query="currently reading"`/`"currently playing"`, then `notion-fetch` hits and keep `Status = Active`. The Active set is small by nature; recall gaps here are harmless.
+2. **Prompt the author** (free-form): which tracked books/games did you **finish** this window (title + date), and what did you newly **start**? Offer the surfaced Active items as the obvious finish candidates, but accept anything.
+3. **Write back** per answer with `notion-update-page` (`command="update_properties"`):
+   - Finished → locate the row (`notion-search` the source by exact title → `notion-fetch` for its `page_id`); set `"Status":"Finished"`, `"date:Finished:start":"<YYYY-MM-DD>"`, `"date:Finished:is_datetime":0`. No matching row? `notion-create-pages` under the `data_source_id` with those same properties.
+   - Started → locate or create the row, set `"Status":"Active"` (`Added` auto-stamps).
+4. Confirm what was written in one line.
+
+Each finish recorded this run is a **completion** kernel for synthesis (review/commentary, almost always `[short]` — see §4). Newly-started / still-Active items are light "currently reading/playing" context, not kernels alone, but they color adjacent themes (e.g. a game whose mechanics echo a work post).
+
+If a source's MCP is unavailable, note which (e.g. "Notion Media Log unavailable — skipped check-in") and continue with the rest.
 
 Mechanical patterns to extract before synthesis:
 

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: digest
-description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, and Reader archives, plus an interactive Notion Media Log check-in (prompts for finished/started books & games and records the status changes) — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`); defaults to `7d` when no cadence is given. Output is thematically clustered in chat; the only side effects are Media Log status updates you confirm and idea issues on request. Promising kernels → `gh issue create --label idea`.
+description: Weekly (or arbitrary cadence) review of GitHub activity, Readwise highlights, and Reader archives, plus an interactive Notion Media Log check-in (asks what you're currently reading/playing, infers completions from whatever dropped off the active list, and records the status changes) — surfaces raw material for brainstorming blog posts. Use via /digest [cadence] where cadence is `Nd|Nw|Nm|Ny` (e.g. `7d`, `4w`, `6m`); defaults to `7d` when no cadence is given. Output is thematically clustered in chat; the only side effects are Media Log status updates you confirm and idea issues on request. Promising kernels → `gh issue create --label idea`.
 ---
 
 # Digest
@@ -49,16 +49,17 @@ Fetch Readwise + Reader for the same window via MCP (using `window.since`, appen
 - Reading (books): `collection://886930b5-cd2e-4528-afe3-0bb6eb1bb8e1`
 - Playing (games): `collection://a37ceaff-e104-4298-b117-aa6ca386a0e6`
 
-Don't try to *detect* completions by querying — **ask the author**; that's the completion edge, and it sidesteps any enumerate-at-scale gap, so the trackers can grow unbounded. Before synthesis:
+Don't *detect* completions by querying — derive them from one "what's active now?" answer per source. The author keeps the active list current; whatever dropped off since the tracker last saw it has been finished. Before synthesis:
 
-1. **Surface Active context** (best-effort, to prime the prompt): per source, `notion-search` `data_source_url=<collection>`, `query="currently reading"`/`"currently playing"`, then `notion-fetch` hits and keep `Status = Active`. The Active set is small by nature; recall gaps here are harmless.
-2. **Prompt the author** (free-form): which tracked books/games did you **finish** this window (title + date), and what did you newly **start**? Offer the surfaced Active items as the obvious finish candidates, but accept anything.
-3. **Write back** per answer with `notion-update-page` (`command="update_properties"`):
-   - Finished → locate the row (`notion-search` the source by exact title → `notion-fetch` for its `page_id`); set `"Status":"Finished"`, `"date:Finished:start":"<YYYY-MM-DD>"`, `"date:Finished:is_datetime":0`. No matching row? `notion-create-pages` under the `data_source_id` with those same properties.
-   - Started → locate or create the row, set `"Status":"Active"` (`Added` auto-stamps).
-4. Confirm what was written in one line.
+1. **Read current Active** (best-effort): per source, `notion-search` `data_source_url=<collection>` (`query` a domain term like `"book"`/`"video game"`), `notion-fetch` the hits, keep `Status = Active` → the *known-active* set. This read can't filter on `Status` server-side, so recall is best-effort — a row it misses just won't be offered this run (stays Active until it surfaces). Self-healing gap, never silent data loss.
+2. **Prompt** (one question per source, free-form): show the known-active titles and ask "what are you actually reading/playing right now?" The author replies with the true current set.
+3. **Diff and write back** (`notion-update-page`, `command="update_properties"`):
+   - known-active **dropped** from the answer → **Finished**: set `"Status":"Finished"`, `"date:Finished:start":"<run date>"`, `"date:Finished:is_datetime":0`. Run date is the default; take an explicit date if the author offers one. If a drop was abandoned rather than finished and they say so → `"Status":"Abandoned"` instead.
+   - answer item **not** in known-active → **newly started**: `notion-search` the source by exact title (precise even in a large table) → flip an existing row to `"Status":"Active"`, or `notion-create-pages` under the `data_source_id` if none exists.
+   - in both → unchanged.
+4. Show the derived diff (finished / started / unchanged) and confirm in one line before moving on.
 
-Each finish recorded this run is a **completion** kernel for synthesis (review/commentary, almost always `[short]` — see §4). Newly-started / still-Active items are light "currently reading/playing" context, not kernels alone, but they color adjacent themes (e.g. a game whose mechanics echo a work post).
+Each item marked Finished this run is a **completion** kernel for synthesis (review/commentary, almost always `[short]` — see §4). Still-active and newly-started items are light "currently reading/playing" context, not kernels alone, but they color adjacent themes (e.g. a game whose mechanics echo a work post).
 
 If a source's MCP is unavailable, note which (e.g. "Notion Media Log unavailable — skipped check-in") and continue with the rest.
 

--- a/.claude/skills/digest/SKILL.md
+++ b/.claude/skills/digest/SKILL.md
@@ -44,7 +44,7 @@ Fetch Readwise + Reader for the same window via MCP (using `window.since`, appen
 - `readwise_list_highlights` — `highlighted_at_gt=<since>T00:00:00Z`, `page_size=100`, `response_fields=["text","note","url","highlighted_at","book_title","book_author"]`.
 - `reader_list_documents` — `location="archive"`, `updated_after=<since>T00:00:00Z`, `limit=100`, `response_fields=["title","author","source","url","last_moved_at","saved_at","category","first_opened_at"]`. **No category filter** — Reader's save/dismiss flow already filters at feed-time, so archive = engaged-with.
 
-**Notion Media Log check-in** — the one place the digest *writes*. Two trackers, schema `Title` / `Status` / `Finished` / `Added` (`Added` auto-stamps creation):
+**Notion Media Log check-in** — the one place the digest *writes*. Two trackers; the digest touches **only** `Title` + `Status` (one of `Active` / `Finished` / `Abandoned`) and leaves any other columns the author keeps (Playing carries `Platform`, hours, `% Done`, etc.) untouched:
 
 - Reading (books): `collection://886930b5-cd2e-4528-afe3-0bb6eb1bb8e1`
 - Playing (games): `collection://a37ceaff-e104-4298-b117-aa6ca386a0e6`
@@ -54,19 +54,19 @@ Don't *detect* completions by querying — derive them from one "what's active n
 1. **Read current Active** (best-effort): per source, `notion-search` `data_source_url=<collection>` (`query` a domain term like `"book"`/`"video game"`), `notion-fetch` the hits, keep `Status = Active` → the *known-active* set. This read can't filter on `Status` server-side, so recall is best-effort — a row it misses just won't be offered this run (stays Active until it surfaces). Self-healing gap, never silent data loss.
 2. **Prompt** (one question per source, free-form): show the known-active titles and ask "what are you actually reading/playing right now?" The author replies with the true current set.
 3. **Diff and write back** (`notion-update-page`, `command="update_properties"`):
-   - known-active **dropped** from the answer → **Finished**: set `"Status":"Finished"`, `"date:Finished:start":"<run date>"`, `"date:Finished:is_datetime":0`. Run date is the default; take an explicit date if the author offers one. If a drop was abandoned rather than finished and they say so → `"Status":"Abandoned"` instead.
+   - known-active **dropped** from the answer → set `"Status":"Finished"` (no date — Status is the whole record). If the author says a drop was abandoned rather than finished → `"Status":"Abandoned"` instead.
    - answer item **not** in known-active → **newly started**: `notion-search` the source by exact title (precise even in a large table) → flip an existing row to `"Status":"Active"`, or `notion-create-pages` under the `data_source_id` if none exists.
    - in both → unchanged.
 4. Show the derived diff (finished / started / unchanged) and confirm in one line before moving on.
 
-Each item marked Finished this run is a **completion** kernel for synthesis (review/commentary, almost always `[short]` — see §4). Still-active and newly-started items are light "currently reading/playing" context, not kernels alone, but they color adjacent themes (e.g. a game whose mechanics echo a work post).
+Each item marked **Finished** this run is a **completion** kernel for synthesis (review/commentary, almost always `[short]` — see §4). **Abandoned** items are just recorded — a did-not-finish can still seed commentary, but only if the author calls it out. Still-active and newly-started items are light "currently reading/playing" context, not kernels alone, but they color adjacent themes (e.g. a game whose mechanics echo a work post).
 
 If a source's MCP is unavailable, note which (e.g. "Notion Media Log unavailable — skipped check-in") and continue with the rest.
 
 Mechanical patterns to extract before synthesis:
 
 - **Cross-source links**: archived Reader docs whose `url` matches a Readwise highlight → tag `has_highlights = true`. A highlight is a stronger engagement signal than archive alone.
-- **Completion arcs**: issues that appear in both `issues_opened` and `issues_closed` within the window, plus Media Log rows that reached `Status = Finished` in-window. Narrative-ready ("started and finished this week"; "finished this book/game — worth a review").
+- **Completion arcs**: issues that appear in both `issues_opened` and `issues_closed` within the window, plus Media Log items marked `Finished` in this run's check-in. Narrative-ready ("started and finished this week"; "finished this book/game — worth a review").
 - **Cross-project signals**: use `repos[].days_active` to spot repos with simultaneous activity bursts. Same kind of work hitting multiple repos on the same days is often a single underlying decision worth surfacing.
 - **Truncation**: if `window.truncated` is non-empty (excluding `commits`-only — squash-dedup destroys most raw items so commits-only truncation is usually noise), surface as a warning above the themed clusters.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,10 @@ Customized and free to edit: `src/config.ts`, `src/constants.ts`,
 
 `.claude/skills/digest/` clusters a window of GitHub activity, Readwise
 highlights, and Reader archives into themes that might seed posts. It
-also runs an interactive Notion Media Log check-in: it prompts for
-books/games finished or started this window and writes the status
-changes back, surfacing each completion as a review kernel. Invoke via
+also runs an interactive Notion Media Log check-in: it asks what you're
+currently reading/playing, infers completions from whatever dropped off
+the active list, and writes the status changes back — surfacing each
+completion as a review kernel. Invoke via
 `/digest [Nd|Nw|Nm|Ny]` (defaults to `7d`). Promising kernels file as
 issues with the `idea` template.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,10 @@ Customized and free to edit: `src/config.ts`, `src/constants.ts`,
 ## Digest skill
 
 `.claude/skills/digest/` clusters a window of GitHub activity, Readwise
-highlights, Reader archives, and Notion Media Log completions
-(books/games finished) into themes that might seed posts. Invoke via
+highlights, and Reader archives into themes that might seed posts. It
+also runs an interactive Notion Media Log check-in: it prompts for
+books/games finished or started this window and writes the status
+changes back, surfacing each completion as a review kernel. Invoke via
 `/digest [Nd|Nw|Nm|Ny]` (defaults to `7d`). Promising kernels file as
 issues with the `idea` template.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,10 @@ Customized and free to edit: `src/config.ts`, `src/constants.ts`,
 ## Digest skill
 
 `.claude/skills/digest/` clusters a window of GitHub activity, Readwise
-highlights, and Reader archives into themes that might seed posts.
-Invoke via `/digest [Nd|Nw|Nm|Ny]` (defaults to `7d`). Promising
-kernels file as issues with the `idea` template.
+highlights, Reader archives, and Notion Media Log completions
+(books/games finished) into themes that might seed posts. Invoke via
+`/digest [Nd|Nw|Nm|Ny]` (defaults to `7d`). Promising kernels file as
+issues with the `idea` template.
 
 ## Tag-suggest skill
 


### PR DESCRIPTION
Add a fourth source to /digest: a hand-maintained Notion tracker of
books (Reading) and games (Playing). A row reaching Status=Finished
with a Finished date in the window is a completion arc, symmetric with
opened+closed issues — narrative-ready, almost always a [short] review
kernel. Active-in-window rows ride along as "currently reading/playing"
context.

Wiring lives in step 2 (MCP fetch, like Readwise/Reader); collect.sh
stays gh-only, so the digest's statelessness is preserved — the
persistent reading/playing state lives in Notion, not the skill. No
property-date filter exists in the Notion MCP, so the recipe is
search-scoped-to-source then post-filter on the fetched Status/Finished.