### PR TITLE
Syndicate new posts to Bluesky via RSS

### DIFF
--- a/.github/workflows/syndicate.yml
+++ b/.github/workflows/syndicate.yml
@@ -1,0 +1,48 @@
+name: Syndicate
+
+# POSSE syndication to Bluesky (see #77). Runs after every successful Pages
+# deploy so a newly published post is posted to @alunduil.bsky.social pointing
+# back at the canonical URL. The script de-duplicates against the live RSS feed
+# and the account's recent posts, so re-runs are harmless. Failures surface
+# through the standard Actions failure notification — that is the pipeline's
+# observability.
+#
+# Setup: create a Bluesky app password (Settings -> App Passwords) and store it
+# as the BLUESKY_APP_PASSWORD repository secret.
+
+on:
+  workflow_run:
+    workflows: [Pages]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: syndicate
+  cancel-in-progress: false
+
+jobs:
+  bluesky:
+    # Skip when the Pages deploy failed; a manual dispatch always runs.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    env:
+      # Public handle; committed as IaC alongside the pipeline (cf. the
+      # webmention username in pages.yml). The app password is the only secret.
+      BLUESKY_IDENTIFIER: alunduil.bsky.social
+      BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.7.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm syndicate

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,5 +14,7 @@ export default [
     },
   },
   { rules: { "no-console": "error" } },
+  // CI scripts report progress to the workflow log; console is the interface.
+  { files: ["scripts/**"], rules: { "no-console": "off" } },
   { ignores: ["dist/**", ".astro", "public/pagefind/**"] },
 ];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "astro": "astro",
     "format:check": "prettier --check .",
     "format": "prettier --write .",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "syndicate": "node scripts/syndicate-bluesky.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.14",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
+    "@atproto/api": "^0.20.16",
     "@pagefind/default-ui": "1.5.2",
     "@shikijs/transformers": "4.2.0",
     "@tailwindcss/typography": "0.5.20",
@@ -36,6 +38,7 @@
     "@typescript-eslint/parser": "8.61.1",
     "eslint": "10.5.0",
     "eslint-plugin-astro": "1.7.0",
+    "fast-xml-parser": "^5.9.3",
     "globals": "17.6.0",
     "pagefind": "1.5.2",
     "prettier": "3.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@astrojs/check':
         specifier: 0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
+      '@atproto/api':
+        specifier: ^0.20.16
+        version: 0.20.16
       '@pagefind/default-ui':
         specifier: 1.5.2
         version: 1.5.2
@@ -69,6 +72,9 @@ importers:
       eslint-plugin-astro:
         specifier: 1.7.0
         version: 1.7.0(eslint@10.5.0(jiti@2.7.0))
+      fast-xml-parser:
+        specifier: ^5.9.3
+        version: 5.9.3
       globals:
         specifier: 17.6.0
         version: 17.6.0
@@ -142,6 +148,34 @@ packages:
 
   '@astrojs/yaml2ts@0.2.4':
     resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@atproto/api@0.20.16':
+    resolution: {integrity: sha512-hKgBgZS9K+ia6AMKo26q75EiDRqvSabpo0SmpeuYRHVGTV+7y35lJVgHtuwGhVXNphyQ0Q9TIg8A5YnRVARXNw==}
+    engines: {node: '>=22'}
+
+  '@atproto/common-web@0.5.1':
+    resolution: {integrity: sha512-nru02gLyzjMQn4ZFgms9ry3kIAKwMaCAvjeFhB9mU6h1ABiSho7aRDbGvnU50CC88TROXuZlgRiEkBjnuiHEtA==}
+    engines: {node: '>=22'}
+
+  '@atproto/lex-data@0.1.2':
+    resolution: {integrity: sha512-NZ4iZvNaqTM6pz+9VRDyEjtozrrf2EDHySNi3Xa8PCzS8gRMCvsnnsvM7r264v4eSqNIDhBB8fr9hfWCHMspXg==}
+    engines: {node: '>=22'}
+
+  '@atproto/lex-json@0.1.1':
+    resolution: {integrity: sha512-FC/NsKHm8TDzWikvf/268T3mMAh6+f31yfCApWC3SvrhWc9c06cSYPp7qzpXcdV0OdB+I5dqHScuTB5OC7HrXg==}
+    engines: {node: '>=22'}
+
+  '@atproto/lexicon@0.7.2':
+    resolution: {integrity: sha512-LVZcTr5+9Qh0okZnNmfRiIDPfbL/6rRxf4goiQxPxwDzaeUDhn4M209i1drmiitbCO1qRLJA2hHF54yNA75Cig==}
+    engines: {node: '>=22'}
+
+  '@atproto/syntax@0.6.2':
+    resolution: {integrity: sha512-h3njTNFl/jv5kTbDqfamQGOJfGbulqLDuAiLbasKwVdBhFyQanpRLa6vE2WqTwv1XEFWLYNMH0KCVsYwT2+aww==}
+    engines: {node: '>=22'}
+
+  '@atproto/xrpc@0.8.1':
+    resolution: {integrity: sha512-sKopRG3an6LN6NfHnRNIEX1fBx3CRtxbNFWQxyse2f86wMcTuXM+/+olN4lVXgFQgv4AWvKTxRXWyuIF2G4YxQ==}
+    engines: {node: '>=22'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -1336,6 +1370,9 @@ packages:
   anynum@1.0.0:
     resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -1363,6 +1400,9 @@ packages:
     engines: {node: ^18.18.0 || >=20.9.0}
     peerDependencies:
       '@astrojs/compiler': '>=0.27.0'
+
+  await-lock@3.0.0:
+    resolution: {integrity: sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1713,6 +1753,10 @@ packages:
     resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
     hasBin: true
 
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1889,12 +1933,18 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -2192,6 +2242,9 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  multiformats@13.4.2:
+    resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -2579,6 +2632,9 @@ packages:
   strnum@2.4.0:
     resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
@@ -2612,6 +2668,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2657,6 +2717,9 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  uint8arrays@5.1.1:
+    resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -2665,6 +2728,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
@@ -2997,6 +3063,9 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3108,6 +3177,53 @@ snapshots:
   '@astrojs/yaml2ts@0.2.4':
     dependencies:
       yaml: 2.9.0
+
+  '@atproto/api@0.20.16':
+    dependencies:
+      '@atproto/common-web': 0.5.1
+      '@atproto/lexicon': 0.7.2
+      '@atproto/syntax': 0.6.2
+      '@atproto/xrpc': 0.8.1
+      await-lock: 3.0.0
+      multiformats: 13.4.2
+      tlds: 1.261.0
+      zod: 3.25.76
+
+  '@atproto/common-web@0.5.1':
+    dependencies:
+      '@atproto/lex-data': 0.1.2
+      '@atproto/lex-json': 0.1.1
+      '@atproto/syntax': 0.6.2
+      zod: 3.25.76
+
+  '@atproto/lex-data@0.1.2':
+    dependencies:
+      multiformats: 13.4.2
+      tslib: 2.8.1
+      uint8arrays: 5.1.1
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.1.1':
+    dependencies:
+      '@atproto/lex-data': 0.1.2
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.7.2':
+    dependencies:
+      '@atproto/common-web': 0.5.1
+      '@atproto/syntax': 0.6.2
+      multiformats: 13.4.2
+      zod: 3.25.76
+
+  '@atproto/syntax@0.6.2':
+    dependencies:
+      iso-datestring-validator: 2.2.2
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.8.1':
+    dependencies:
+      '@atproto/lexicon': 0.7.2
+      zod: 3.25.76
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -4041,6 +4157,8 @@ snapshots:
 
   anynum@1.0.0: {}
 
+  anynum@1.0.1: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -4163,6 +4281,8 @@ snapshots:
     dependencies:
       '@astrojs/compiler': 3.0.1
       synckit: 0.11.13
+
+  await-lock@3.0.0: {}
 
   axobject-query@4.1.0: {}
 
@@ -4526,6 +4646,15 @@ snapshots:
       strnum: 2.4.0
       xml-naming: 0.1.0
 
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4726,11 +4855,15 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-unsafe@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  iso-datestring-validator@2.2.2: {}
 
   jiti@2.7.0: {}
 
@@ -5184,6 +5317,8 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  multiformats@13.4.2: {}
 
   nanoid@3.3.12: {}
 
@@ -5648,6 +5783,10 @@ snapshots:
     dependencies:
       anynum: 1.0.0
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   suf-log@2.5.3:
     dependencies:
       s.color: 0.0.15
@@ -5681,6 +5820,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tlds@1.261.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5693,8 +5834,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -5721,11 +5861,17 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  uint8arrays@5.1.1:
+    dependencies:
+      multiformats: 13.4.2
+
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
 
   undici-types@7.18.2: {}
+
+  unicode-segmenter@0.14.5: {}
 
   unicode-trie@2.0.0:
     dependencies:
@@ -6006,6 +6152,8 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoga-layout@3.2.1: {}
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/scripts/syndicate-bluesky.mjs
+++ b/scripts/syndicate-bluesky.mjs
@@ -1,0 +1,137 @@
+// Syndicate newly published posts to Bluesky (POSSE; see issue #77).
+//
+// The blog stays canonical; Bluesky is a notification channel pointing back.
+// Source of truth is the live RSS feed, which already gates on publish time
+// (src/utils/postFilter.ts), so future-dated posts never leak here.
+//
+// De-duplication has two independent guards, so no state file is committed:
+//   1. A recency window (SYNDICATE_WINDOW_HOURS) bounds what is eligible. On
+//      first run this keeps the entire archive from flooding Bluesky, and it
+//      stops a post from re-syndicating forever once it ages out.
+//   2. Within that window, the author's recent Bluesky feed is queried and any
+//      post whose canonical URL already appears there is skipped. This catches
+//      the common case of multiple deploys on the same day.
+//
+// Known gap: editing a post older than the window sets RSS pubDate to its
+// modDatetime, which can pull it back into the window; if its original
+// syndication has scrolled past the queried feed depth it would re-post. Rare
+// for a low-volume blog — revisit if it bites.
+
+import { AtpAgent, RichText } from "@atproto/api";
+import { XMLParser } from "fast-xml-parser";
+
+const FEED_URL = process.env.FEED_URL ?? "https://blog.alunduil.com/rss.xml";
+const SERVICE = process.env.BLUESKY_SERVICE ?? "https://bsky.social";
+const WINDOW_HOURS = Number(process.env.SYNDICATE_WINDOW_HOURS ?? "48");
+const DRY_RUN =
+  process.env.DRY_RUN === "true" || process.argv.includes("--dry-run");
+
+// Bluesky caps post text at 300 graphemes; the embed card carries the full
+// title and description regardless, so the text is just a teaser.
+const MAX_GRAPHEMES = 300;
+const FEED_PAGES = 3;
+const FEED_PAGE_SIZE = 100;
+
+function fail(message) {
+  console.error(`syndicate: ${message}`);
+  process.exit(1);
+}
+
+async function fetchPublishedItems() {
+  const res = await fetch(FEED_URL);
+  if (!res.ok) fail(`fetching ${FEED_URL} returned ${res.status}`);
+  const parser = new XMLParser();
+  const feed = parser.parse(await res.text());
+  const items = feed?.rss?.channel?.item ?? [];
+  // fast-xml-parser collapses a single <item> to an object.
+  return (Array.isArray(items) ? items : [items]).map(item => ({
+    title: String(item.title),
+    description: String(item.description),
+    link: String(item.link),
+    pubDate: new Date(item.pubDate),
+  }));
+}
+
+// Every canonical URL already on the author's recent feed, gathered from the
+// external embed (where we put the link) and the post text as a fallback.
+async function fetchSyndicatedUrls(agent, actor) {
+  const urls = new Set();
+  let cursor;
+  for (let page = 0; page < FEED_PAGES; page++) {
+    const { data } = await agent.getAuthorFeed({
+      actor,
+      limit: FEED_PAGE_SIZE,
+      cursor,
+    });
+    for (const { post } of data.feed) {
+      const embedUri = post.embed?.external?.uri;
+      if (embedUri) urls.add(embedUri);
+      const text = post.record?.text;
+      if (text) {
+        for (const match of text.matchAll(/https?:\/\/\S+/g)) {
+          urls.add(match[0]);
+        }
+      }
+    }
+    cursor = data.cursor;
+    if (!cursor) break;
+  }
+  return urls;
+}
+
+function buildText(title, description) {
+  const full = `${title}\n\n${description}`;
+  if (new RichText({ text: full }).graphemeLength <= MAX_GRAPHEMES) return full;
+  // Trim the hook, never the title; reserve room for the title, separator,
+  // and ellipsis.
+  const reserved = Array.from(`${title}\n\n…`).length;
+  const room = MAX_GRAPHEMES - reserved;
+  const hook = Array.from(description).slice(0, Math.max(0, room)).join("");
+  return `${title}\n\n${hook}…`;
+}
+
+async function post(agent, item) {
+  const text = buildText(item.title, item.description);
+  const rt = new RichText({ text });
+  await rt.detectFacets(agent);
+  await agent.post({
+    text: rt.text,
+    facets: rt.facets,
+    embed: {
+      $type: "app.bsky.embed.external",
+      external: {
+        uri: item.link,
+        title: item.title,
+        description: item.description,
+      },
+    },
+    createdAt: new Date().toISOString(),
+  });
+}
+
+const identifier = process.env.BLUESKY_IDENTIFIER;
+const password = process.env.BLUESKY_APP_PASSWORD;
+if (!identifier) fail("BLUESKY_IDENTIFIER is not set");
+if (!password) fail("BLUESKY_APP_PASSWORD is not set");
+
+const agent = new AtpAgent({ service: SERVICE });
+await agent.login({ identifier, password });
+
+const cutoff = Date.now() - WINDOW_HOURS * 60 * 60 * 1000;
+const items = await fetchPublishedItems();
+const recent = items.filter(item => item.pubDate.getTime() >= cutoff);
+const syndicated = await fetchSyndicatedUrls(agent, identifier);
+const pending = recent.filter(item => !syndicated.has(item.link));
+
+console.log(
+  `syndicate: ${items.length} in feed, ${recent.length} within ${WINDOW_HOURS}h, ${pending.length} to post`
+);
+
+for (const item of pending) {
+  if (DRY_RUN) {
+    console.log(`syndicate: [dry-run] would post ${item.link}`);
+    continue;
+  }
+  await post(agent, item);
+  console.log(`syndicate: posted ${item.link}`);
+}


### PR DESCRIPTION
## Summary

Superseded by [ADR 0001](https://github.com/alunduil/blog.alunduil.com/blob/main/docs/adr/0001-use-dlvrit-for-social-syndication.md), which decides the syndication mechanism is dlvr.it across all platforms and explicitly rejects self-hosted per-platform posters (the approach in this PR). Bluesky is covered by routing the same RSS feed through dlvr.it, so this self-hosted pipeline is both contrary to the ADR and redundant.

Closing unmerged. Issue #77 continues via a dlvr.it how-to (mirroring the Threads how-to from #266).