### PR TITLE
Add agent-readiness manifests for Cloudflare scanner

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import { getPath } from "@/utils/getPath";
+import getSortedPosts from "@/utils/getSortedPosts";
+import { SITE } from "@/config";
+
+export const GET: APIRoute = async ({ site }) => {
+  const posts = getSortedPosts(await getCollection("blog"));
+
+  const postLines = posts.map(({ data, id, filePath }) => {
+    const url = new URL(`${getPath(id, filePath)}/index.md`, site).href;
+    return `- [${data.title}](${url}): ${data.description}`;
+  });
+
+  const body = `# ${SITE.title}
+
+> ${SITE.desc}
+
+This is the personal blog of ${SITE.author}. Every post below is also available as clean Markdown at its \`index.md\` URL.
+
+## Posts
+
+${postLines.join("\n")}
+
+## About
+
+- [About](${new URL("about", site).href}): About the author.
+`;
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/posts/[...slug]/index.md.ts
+++ b/src/pages/posts/[...slug]/index.md.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from "astro";
+import { getCollection, type CollectionEntry } from "astro:content";
+import { getPath } from "@/utils/getPath";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.map(post => ({
+    params: { slug: getPath(post.id, post.filePath, false) },
+    props: { post },
+  }));
+}
+
+export const GET: APIRoute = ({ props }) => {
+  const { post } = props as { post: CollectionEntry<"blog"> };
+  return new Response(`# ${post.data.title}\n\n${post.body}`, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from "astro";
 
 const getRobotsTxt = (sitemapURL: URL) => `
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 
 Sitemap: ${sitemapURL.href}


### PR DESCRIPTION
## Summary

Adds the agent-discoverability manifests so the site scans cleanly against [Cloudflare's Agent Readiness scanner](https://blog.cloudflare.com/agent-readiness/): an explicit `Content-Signal` in `robots.txt`, a structured `llms.txt` reading list, and a clean-Markdown form of every post.

Two decisions the issue asked to record (both via direct ask):
- **Content-Signal posture: fully open** — `search=yes, ai-input=yes, ai-train=yes`. Leaving it implicit itself reads as a refuse signal.
- **Edge layer: accept the GitHub Pages ceiling now.** `Link:` headers (RFC 8288) need response-header control bare Pages doesn't offer; deferred to a possible Cloudflare-proxy move under alunduil-infrastructure#7. The `.well-known` items are servable but have no skills/bot infra to back them today, so they're left out.

## Gotchas

- `index.md` endpoints mirror `index.astro`'s `getStaticPaths` exactly (`!data.draft`), so the `.md` set is 1:1 with the `.html` post set. `llms.txt` instead uses `getSortedPosts` (drops future-scheduled posts) — it's the *published* reading list, not the build set.
- Static `.md` files are served by GitHub Pages as `text/markdown` by extension; the `Content-Type` header in the endpoint only applies in dev/SSR.

## Verification

- `pnpm build` clean; confirmed `dist/robots.txt`, `dist/llms.txt`, `dist/sitemap-index.xml`, and a `posts/<slug>/index.md` for all 20 published posts (the only `.md`-less dirs under `posts/` are the 5 pagination pages).
- The live isitagentready.com scan (acceptance criterion #1) can only run after merge + deploy.

Refs #76 — kept intentionally *not* `Closes`, so the issue stays open until the live scan is verified against the deployed site post-merge.