### PR TITLE
Settle title and align branding to the OG card

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ export const SITE = {
   website: "https://blog.alunduil.com/",
   author: "Alex Brandt",
   profile: "https://github.com/alunduil",
-  desc: "Notes on production software engineering, reliability, observability, and feedback-loop systems.",
+  desc: "Working notes from a production software engineer on reliability, observability, and feedback-loop systems.",
   title: "alunduil",
   ogImage: "og.png",
   lightAndDarkMode: true,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,7 @@
 html[data-theme="light"] {
   --background: #fdfdfd;
   --foreground: #282728;
-  --accent: #006cac;
+  --accent: #1e4fa1;
   --muted: #e6e6e6;
   --border: #ece9e9;
 }
@@ -15,9 +15,9 @@ html[data-theme="light"] {
 html[data-theme="dark"] {
   --background: #212737;
   --foreground: #eaedf3;
-  --accent: #ff6b01;
+  --accent: #d5232a;
   --muted: #343f60;
-  --border: #ab4b08;
+  --border: #8e171c;
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary

Settles the title and branding decision for #56. The title stays `alunduil`, promoted from interim alias to the deliberate site title. `SITE.desc` moves from a topical list to the about page's working-notes voice, and the theme accents now match the De Stijl OG card instead of an unrelated blue/orange. Header wordmark typography is split to #272 — it needs IBM Plex Sans as a browser webfont.

Closes #56

## Gotchas

- Dark-mode `--border` retoned from orange (`#ab4b08`) to deep red (`#8e171c`): it tracked the *old* orange accent and would clash with the new De Stijl red. Light border/muted are neutral greys, so only dark needed it — worth eyeballing the dark theme, since it's the one judgment call here.

## Verification

- `npm run build` clean; confirmed the reframed desc propagated to the meta description, `og:`/`twitter:` descriptions, RSS, and llms.txt in the built output.