### PR TITLE
Add post: The Bottleneck Isn't the Blank Page

### DIFF
--- a/.claude/skills/outline-draft/SKILL.md
+++ b/.claude/skills/outline-draft/SKILL.md
@@ -97,10 +97,15 @@ failure signatures:
    hide") instead of naming something concrete → ground it: say *which*
    machine, *what* output, *what* it actually does.
 
+The title in the header is a **working title** — a handle for the file
+and the angle, not a commitment. The real title is chosen in `post-draft`
+once the prose exists and the body settles what it argues; don't burn
+approval cycles refining it here.
+
 ## Shape
 
 ```markdown
-# <Title> — outline
+# <Working title> — outline
 
 <Logline: the one moment of change, where the story opens (its
 opposite), the surrounding years as context, open questions to confirm.>

--- a/.claude/skills/outline-draft/SKILL.md
+++ b/.claude/skills/outline-draft/SKILL.md
@@ -41,6 +41,12 @@ Picking up an idea issue (`gh issue view #N`): use `## Spark` + `## Why
 it could be interesting` as the kernel; open questions become discovery
 anchors.
 
+The moment of change and the feeling around it are claims too, not just
+the dates. State the inferred climax and any inferred motivation back to
+the author as assumptions to confirm or kill *before* building the arc on
+them — a wrong peak or a wrong emotional thread costs scenes to unwind,
+where a wrong fact costs a parenthetical.
+
 Substance lands as the outline file's **header**: the logline (the one
 moment of change), where the story opens (its opposite), and the open
 questions / anchors still to confirm. That header is phase 1's output
@@ -79,7 +85,7 @@ are the author's to supply — anchor the provable, ask for the rest.
 
 ## 3. Diagnose
 
-Before approval, read the beats top to bottom and check the eight
+Before approval, read the beats top to bottom and check the nine
 failure signatures:
 
 1. **Overloaded scene** — one scene carrying two changes → split.
@@ -90,12 +96,18 @@ failure signatures:
 5. **Flat arc** — the first scene isn't the opposite of the last, so
    there's no contrast to feel.
 6. **Unanchored claim** — a factual beat with no parenthetical and not
-   marked TBD.
+   marked TBD. Includes false precision: a beat asserting a count or
+   certainty ("the one story") the subject doesn't bear → state the real
+   range ("zero or more").
 7. **Topic-naming** — a scene named like a section → drifting to essay.
 8. **Amorphous phrase** — a beat that gestures abstractly ("the thing,"
    "points outward," "opposite purpose," "push the work out," "places to
    hide") instead of naming something concrete → ground it: say *which*
    machine, *what* output, *what* it actually does.
+9. **Double climax** — the arc builds to two different moments of change,
+   so the peak is split and the title points at only one. Demote one to
+   setup or to the landing. Test (mirrors `post-draft`): state the single
+   moment in one sentence, and only one.
 
 The title in the header is a **working title** — a handle for the file
 and the angle, not a commitment. The real title is chosen in `post-draft`

--- a/.vale.ini
+++ b/.vale.ini
@@ -21,6 +21,10 @@ Vale.Spelling = NO
 # voice ("do not", "is not"). Suggestion preserves tonal range.
 Microsoft.Contractions = suggestion
 
+# Dates are RFC 3339 (YYYY-MM-DD), matching the ISO 8601 frontmatter
+# timestamps. The Microsoft rule mandates US "Month DD, YYYY"; disable it.
+Microsoft.DateFormat = NO
+
 # A personal blog is first person by design (titles like "How I Read");
 # the impersonal-voice rule is all false positives here.
 Microsoft.FirstPerson = NO

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -114,6 +114,9 @@ LaTeX
 # Games
 Warcraft
 
+# Books and fiction
+Earthsea
+
 # Domain terms (suppress Microsoft.Terms swaps that don't fit a blog
 # about AI coding agents).
 agent

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,4 +18,5 @@ exclude_path = [
   "(^|/)src/data/blog/how-i-read-eight-years-on\\.md$",
   "(^|/)src/data/blog/how-i-back-up\\.md$",
   "(^|/)src/data/blog/i-built-the-machine-twice\\.md$",
+  "(^|/)src/data/blog/the-bottleneck-isnt-the-blank-page\\.md$",
 ]

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -1,0 +1,61 @@
+# The Bottleneck Isn't the Blank Page — outline
+
+**Working title — settle with author.** The hook is that the stall *feels*
+like a blank page (no ideas) but is the opposite: a week too full to parse,
+its material fading into private notes before it can be seen.
+
+Logline: the moment the bottleneck moves — from "I have nothing to write
+about" to "I can't see which slice of what I already did has post-shape."
+Opens at its opposite: the blog reopened, the intent to post regularly, and
+the week's work sliding into Obsidian/Notion where no one — not even me —
+will reference it again. Surrounding context: an activity-lookback I already
+run at work to find where I'm having impact, pointed at the blog. The build
+itself is minor (fire-and-forget); the reframe is the story.
+
+The honesty line: discovery is *proven* (the idea backlog keeps filling),
+the cadence payoff is *unproven* (zero posts shipped yet). The post lands on
+that bet, not a victory lap — owns the open outcome instead of apologising
+for it. No "the digest wrote this post" recursion (rejected as a forced
+quip); the proof of discovery is the filling backlog, full stop.
+
+Sequel to [I Built the Machine Twice](/posts/i-built-the-machine-twice)
+(pub 2026-06-30): that post = why I came back; this = the mechanism for
+finding what to share. Open the post *after* the dust-off, don't re-tell it.
+
+## 1. The page that wasn't blank — *the opposite*
+
+1. The blog's open again, and this time I meant to actually keep posting *(picks up after /posts/i-built-the-machine-twice)*
+2. Sit down to write and nothing comes; the week's already a blur
+3. It reads like a blank-page problem — writing is the hard part, I've got nothing
+4. But the week wasn't empty; its work had gone where work goes — Obsidian, Notion — private, unreferenced, even by me *(author's framing)*
+
+## 2. The lookback I already run — *the lift*
+
+1. At work I do a regular lookback over my activity to see where I'm having impact and where effort's going wrong *(author)*
+2. That material is never invented — it's reviewed; the week already happened
+3. Same move shows up elsewhere — Ashley Willis's evening "Daily Wins Recap" automation: the lookback to recognise impact you'd otherwise check off and forget *(github.blog, "I automated my job (and it made me a better leader)")*
+4. The blank page was never the problem at work — so why was I treating the blog like one
+
+## 3. Point it at the blog — *the turn*
+
+1. The week is exhaust — commits, highlights, archives, a finished book — produced whether or not I capture it
+2. Build the digest: fan out across the sources for one window *(GitHub, Readwise, Reader, Notion Media Log; .claude/skills/digest)*
+3. Throw out the noise that isn't signal — squash-merge dupes, agent-branch churn *(collect.sh heuristics)*
+4. Cluster what's left into a handful of themes, each a candidate post *(4–8 themes; SKILL.md §3)*
+5. The bottleneck moves: not drafting, but seeing which slice had shape before it evaporated *(the thesis; #126)*
+
+## 4. The bet — *the landing*
+
+1. What's proven is discovery: a run reliably turns a week of exhaust into post-shaped kernels — the idea backlog keeps filling *(51 idea issues filed / 46 open as of 2026-06)*
+2. Honestly, only ~60% are arcs worth recording, and they filter further from there *(author: ~60%; still too early to guess the fill rate)*
+3. What the kernels look like — a 49-PR week braided with reading Flow; a short-game review off the media log *(#231, #250 — concrete output)*
+4. What's not proven is the payoff: posts actually shipped is zero, this nearly the first — the cadence is the bet, not the receipt *(Machine Twice #260, pub 2026-06-30)*
+5. Cheap to keep the bet open — fire-and-forget, value almost immediately, the tuning since is minor friction *(author)*
+6. And the bet is only as good as your exhaust — my work leaves clean logs; yours might be Todoist, a calendar, whatever trail you already leave *(author)*
+
+## Open
+
+- **Digest attribution:** 51 idea issues carry the `idea` label, but not every one is necessarily digest-sourced (some may be hand-filed). Confirm before implying the digest produced all 51 — safest to frame as "kernels filed" / "the idea backlog" rather than "the digest filed 51."
+- **Title/slug:** working "The Bottleneck Isn't the Blank Page" — finalised after the prose exists (post-draft derives title from the body), not now.
+- **Scope guard:** keep on the discovery/bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
+- **Sources concrete vs abstract:** scene 3 names sources explicitly; confirm that's the right altitude vs. keeping "exhaust" abstract until the close.

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -16,7 +16,9 @@ reason zero have shipped yet.
 Sequel to [I Built the Machine Twice](/posts/i-built-the-machine-twice)
 (pub 2026-06-30): that post = why I came back and built the machine; this =
 the part of the machine that finds what to write. The coauthoring premise
-is established there; pick it up, don't re-argue it.
+is established there; pick it up, don't re-argue it. Coauthoring stays a
+plain, unhidden *nod* — threaded through scenes 1 and 4, never the subject
+(coauthoring-as-focus is #73/#67). The forest/discovery reframe is the story.
 
 The honesty line: discovery is *proven* (the idea backlog keeps filling),
 the publishing payoff is *unproven* (zero posts shipped yet — the craft
@@ -60,6 +62,5 @@ discovery is the filling backlog, full stop.
 
 - **Digest attribution:** 51 idea issues carry the `idea` label, but not every one is necessarily digest-sourced (some may be hand-filed). Confirm before implying the digest produced all 51 — safest to frame as "the idea backlog" / "kernels filed" rather than "the digest filed 51."
 - **Title/slug:** working "The Bottleneck Isn't the Blank Page" — finalised after the prose exists (post-draft derives title from the body), not now.
-- **Coauthoring candour:** the post says outright that Claude coauthors/ghost-writes the prose. Confirm that's the register you want stated plainly (it's the spine of the whole reframe), vs. left implicit.
 - **Scope guard:** keep on the discovery-then-publishing-bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
 - **Sources concrete vs abstract:** scene 3 names sources explicitly; confirm that's the right altitude vs. keeping "exhaust" abstract until the close.

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -4,15 +4,16 @@
 problem because writing was handed off from the start — coauthoring with
 Claude was always the plan. Real title settled in post-draft.
 
-Logline: the moment the bottleneck is relocated — the hard part of the
-blog was never the writing (that's coauthored with Claude); it's that the
-week is a forest I've forgotten by Friday, and the stories worth telling are
-leaves I can't pick out of the blur.
-Opens at its opposite — the universal assumption that a blog stalls on the
-blank page and the discipline to fill it. Builds to the bet: digest solves
-*discovery* (the backlog fills), but *publishing* each kernel — review,
-craft, coauthoring — is the remaining bottleneck, which is the honest
-reason zero have shipped yet.
+Logline — the one moment of change: the bottleneck was never the writing
+(that's coauthored with Claude) but *seeing* — the week is a forest I've
+forgotten by Friday, and the stories worth telling are leaves I can't pick
+out of the blur. Opens at its opposite — the universal assumption that a
+blog stalls on the blank page and the discipline to fill it.
+
+The publishing bet (discovery is solved, the backlog fills; publishing each
+kernel through review/craft/coauthoring is the slow part — the honest reason
+zero have shipped) is the *landing*, not a second climax. Hold scene 4 as
+resolution; the single peak is the *seeing* reframe.
 
 Sequel to [I Built the Machine Twice](/posts/i-built-the-machine-twice)
 (pub 2026-06-30): that post = why I came back and built the machine; this =
@@ -39,7 +40,7 @@ discovery is the filling backlog, full stop.
 
 1. I already fight this forgetting at work — a regular lookback over my activity to see where I had impact and where I didn't *(author)*
 2. That material is never invented; it's reviewed — the week already happened, I just couldn't hold it
-3. Same move elsewhere — Ashley Willis's evening "Daily Wins Recap," the lookback that catches the wins you'd check off and forget *(github.blog, "I automated my job (and it made me a better leader)")*
+3. Same move elsewhere — Ashley Willis's evening "Daily Wins Recap," the lookback that catches the wins you'd check off and forget *(cite canonical, not the private Reader URL: https://github.blog/developer-skills/github/i-automated-my-job-and-it-made-me-a-better-leader/)*
 4. If a lookback finds my impact at work, it can find my stories on the blog
 
 ## 3. Point it at the blog — *the turn*

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -1,61 +1,65 @@
 # The Bottleneck Isn't the Blank Page — outline
 
-**Working title — settle with author.** The hook is that the stall *feels*
-like a blank page (no ideas) but is the opposite: a week too full to parse,
-its material fading into private notes before it can be seen.
+**Working title.** Now earned literally: the blank page was never the
+problem because writing was handed off from the start — coauthoring with
+Claude was always the plan. Real title settled in post-draft.
 
-Logline: the moment the bottleneck moves — from "I have nothing to write
-about" to "I can't see which slice of what I already did has post-shape."
-Opens at its opposite: the blog reopened, the intent to post regularly, and
-the week's work sliding into Obsidian/Notion where no one — not even me —
-will reference it again. Surrounding context: an activity-lookback I already
-run at work to find where I'm having impact, pointed at the blog. The build
-itself is minor (fire-and-forget); the reframe is the story.
-
-The honesty line: discovery is *proven* (the idea backlog keeps filling),
-the cadence payoff is *unproven* (zero posts shipped yet). The post lands on
-that bet, not a victory lap — owns the open outcome instead of apologising
-for it. No "the digest wrote this post" recursion (rejected as a forced
-quip); the proof of discovery is the filling backlog, full stop.
+Logline: the moment the bottleneck is relocated — the hard part of the
+blog was never the writing (that's coauthored with Claude); it's that the
+week is a forest I've forgotten by Friday, and the story is one leaf in it.
+Opens at its opposite — the universal assumption that a blog stalls on the
+blank page and the discipline to fill it. Builds to the bet: digest solves
+*discovery* (the backlog fills), but *publishing* each kernel — review,
+craft, coauthoring — is the remaining bottleneck, which is the honest
+reason zero have shipped yet.
 
 Sequel to [I Built the Machine Twice](/posts/i-built-the-machine-twice)
-(pub 2026-06-30): that post = why I came back; this = the mechanism for
-finding what to share. Open the post *after* the dust-off, don't re-tell it.
+(pub 2026-06-30): that post = why I came back and built the machine; this =
+the part of the machine that finds what to write. The coauthoring premise
+is established there; pick it up, don't re-argue it.
 
-## 1. The page that wasn't blank — *the opposite*
+The honesty line: discovery is *proven* (the idea backlog keeps filling),
+the publishing payoff is *unproven* (zero posts shipped yet — the craft
+loop is slow). The post lands on that bet, not a victory lap. No "the
+digest wrote this post" recursion (rejected as a forced quip); the proof of
+discovery is the filling backlog, full stop.
 
-1. The blog's open again, and this time I meant to actually keep posting *(picks up after /posts/i-built-the-machine-twice)*
-2. Sit down to write and nothing comes; the week's already a blur
-3. It reads like a blank-page problem — writing is the hard part, I've got nothing
-4. But the week wasn't empty; its work had gone where work goes — Obsidian, Notion — private, unreferenced, even by me *(author's framing)*
+## 1. The bottleneck was never the blank page — *the opposite*
+
+1. The story everyone tells about blogging: the hard part is the writing — the blank page, the discipline to fill it
+2. I never planned to fill it by hand — coauthoring with Claude was the plan from the first *(premise carried from /posts/i-built-the-machine-twice)*
+3. So the page was never my problem; mine is the opposite of empty
+4. The week is a forest I've forgotten by Friday — a hundred small things that add up to something chunky, invisible one at a time *(author: I forget the week; small things sum)*
+5. Finding the one story-shaped leaf in that forest is the actual hard part *(forest/leaf)*
 
 ## 2. The lookback I already run — *the lift*
 
-1. At work I do a regular lookback over my activity to see where I'm having impact and where effort's going wrong *(author)*
-2. That material is never invented — it's reviewed; the week already happened
-3. Same move shows up elsewhere — Ashley Willis's evening "Daily Wins Recap" automation: the lookback to recognise impact you'd otherwise check off and forget *(github.blog, "I automated my job (and it made me a better leader)")*
-4. The blank page was never the problem at work — so why was I treating the blog like one
+1. I already fight this forgetting at work — a regular lookback over my activity to see where I had impact and where I didn't *(author)*
+2. That material is never invented; it's reviewed — the week already happened, I just couldn't hold it
+3. Same move elsewhere — Ashley Willis's evening "Daily Wins Recap," the lookback that catches the wins you'd check off and forget *(github.blog, "I automated my job (and it made me a better leader)")*
+4. If a lookback finds my impact at work, it can find my stories on the blog
 
 ## 3. Point it at the blog — *the turn*
 
-1. The week is exhaust — commits, highlights, archives, a finished book — produced whether or not I capture it
-2. Build the digest: fan out across the sources for one window *(GitHub, Readwise, Reader, Notion Media Log; .claude/skills/digest)*
+1. The week is exhaust — commits, reviews, highlights, a finished book — produced whether or not I remember it
+2. Build the digest: fan out across the sources for one window and summarise the week *(GitHub, Readwise, Reader, Notion Media Log; .claude/skills/digest)*
 3. Throw out the noise that isn't signal — squash-merge dupes, agent-branch churn *(collect.sh heuristics)*
-4. Cluster what's left into a handful of themes, each a candidate post *(4–8 themes; SKILL.md §3)*
-5. The bottleneck moves: not drafting, but seeing which slice had shape before it evaporated *(the thesis; #126)*
+4. Cluster the forest into a handful of themes — each a story-shaped leaf made visible *(4–8 themes; SKILL.md §3)*
+5. It feeds the pipeline, doesn't replace it — the kernels still go to review, craft, coauthoring *(digest builds publications, not finished posts)*
 
 ## 4. The bet — *the landing*
 
-1. What's proven is discovery: a run reliably turns a week of exhaust into post-shaped kernels — the idea backlog keeps filling *(51 idea issues filed / 46 open as of 2026-06)*
+1. Discovery is the solved part: a run reliably turns the week into post-shaped kernels — the backlog keeps filling *(51 idea issues filed / 46 open as of 2026-06)*
 2. Honestly, only ~60% are arcs worth recording, and they filter further from there *(author: ~60%; still too early to guess the fill rate)*
 3. What the kernels look like — a 49-PR week braided with reading Flow; a short-game review off the media log *(#231, #250 — concrete output)*
-4. What's not proven is the payoff: posts actually shipped is zero, this nearly the first — the cadence is the bet, not the receipt *(Machine Twice #260, pub 2026-06-30)*
-5. Cheap to keep the bet open — fire-and-forget, value almost immediately, the tuning since is minor friction *(author)*
+4. The unsolved part is publishing: review, craft, coauthoring is the real bottleneck — and the honest reason posts actually shipped is still zero, this nearly the first *(Machine Twice #260, pub 2026-06-30)*
+5. Cheap to keep the bet open — digest is fire-and-forget, value almost immediately, the tuning since is minor friction *(author)*
 6. And the bet is only as good as your exhaust — my work leaves clean logs; yours might be Todoist, a calendar, whatever trail you already leave *(author)*
 
 ## Open
 
-- **Digest attribution:** 51 idea issues carry the `idea` label, but not every one is necessarily digest-sourced (some may be hand-filed). Confirm before implying the digest produced all 51 — safest to frame as "kernels filed" / "the idea backlog" rather than "the digest filed 51."
+- **Digest attribution:** 51 idea issues carry the `idea` label, but not every one is necessarily digest-sourced (some may be hand-filed). Confirm before implying the digest produced all 51 — safest to frame as "the idea backlog" / "kernels filed" rather than "the digest filed 51."
 - **Title/slug:** working "The Bottleneck Isn't the Blank Page" — finalised after the prose exists (post-draft derives title from the body), not now.
-- **Scope guard:** keep on the discovery/bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
+- **Coauthoring candour:** the post says outright that Claude coauthors/ghost-writes the prose. Confirm that's the register you want stated plainly (it's the spine of the whole reframe), vs. left implicit.
+- **Scope guard:** keep on the discovery-then-publishing-bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
 - **Sources concrete vs abstract:** scene 3 names sources explicitly; confirm that's the right altitude vs. keeping "exhaust" abstract until the close.

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -45,7 +45,7 @@ discovery is the filling backlog, full stop.
 ## 3. Point it at the blog — *the turn*
 
 1. The week is exhaust — commits, reviews, highlights, a finished book — produced whether or not I remember it
-2. Build the digest: fan out across the sources for one window and summarise the week *(GitHub, Readwise, Reader, Notion Media Log; .claude/skills/digest)*
+2. Build the digest: fan out across the sources for one window and summarise the week *(GitHub, Readwise, Reader, Notion Media Log; link "the digest" → github.com/alunduil/blog.alunduil.com/tree/main/.claude/skills/digest)*
 3. Throw out the noise that isn't signal — squash-merge dupes, agent-branch churn *(collect.sh heuristics)*
 4. Cluster the forest into a handful of themes — each a story-shaped leaf made visible *(4–8 themes; SKILL.md §3)*
 5. It feeds the pipeline, doesn't replace it — the kernels still go to review, craft, coauthoring *(digest builds publications, not finished posts)*

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -51,16 +51,15 @@ discovery is the filling backlog, full stop.
 
 ## 4. The bet — *the landing*
 
-1. Discovery is the solved part: a run reliably turns the week into post-shaped kernels — the backlog keeps filling *(51 idea issues filed / 46 open as of 2026-06)*
-2. Honestly, only ~60% are arcs worth recording, and they filter further from there *(author: ~60%; still too early to guess the fill rate)*
+1. Discovery is the solved part: I run it every Saturday, and the backlog fills in weekly waves *(51 idea issues / 46 open across 8 weeks; ~90% filed Sat–Mon — the weekend tail of a Saturday run — as of 2026-06)*
+2. Some weeks a run surfaces nothing worth keeping; usually it's more — a handful, ~60% of them arcs worth recording, filtering further from there *(author: could be zero, usually more; ~60%; too early to guess the post fill rate)*
 3. What the kernels look like — a 49-PR week braided with reading Flow; a short-game review off the media log *(#231, #250 — concrete output)*
 4. The unsolved part is publishing: review, craft, coauthoring is the real bottleneck — and the honest reason posts actually shipped is still zero, this nearly the first *(Machine Twice #260, pub 2026-06-30)*
-5. Cheap to keep the bet open — digest is fire-and-forget, value almost immediately, the tuning since is minor friction *(author)*
+5. Cheap to keep the bet open — the weekly run is fire-and-forget, value almost immediately, the tuning since is minor friction *(author)*
 6. And the bet is only as good as your exhaust — my work leaves clean logs; yours might be Todoist, a calendar, whatever trail you already leave *(author)*
 
 ## Open
 
-- **Digest attribution:** 51 idea issues carry the `idea` label, but not every one is necessarily digest-sourced (some may be hand-filed). Confirm before implying the digest produced all 51 — safest to frame as "the idea backlog" / "kernels filed" rather than "the digest filed 51."
 - **Title/slug:** working "The Bottleneck Isn't the Blank Page" — finalised after the prose exists (post-draft derives title from the body), not now.
 - **Scope guard:** keep on the discovery-then-publishing-bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
 - **Sources concrete vs abstract:** scene 3 names sources explicitly; confirm that's the right altitude vs. keeping "exhaust" abstract until the close.

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -47,8 +47,8 @@ discovery is the filling backlog, full stop.
 1. The week is exhaust — commits, reviews, highlights, a finished book — produced whether or not I remember it
 2. Build the digest: fan out across the sources for one window and summarise the week *(GitHub, Readwise, Reader, Notion Media Log; link "the digest" → github.com/alunduil/blog.alunduil.com/tree/main/.claude/skills/digest)*
 3. Throw out the noise that isn't signal — squash-merge dupes, agent-branch churn *(collect.sh heuristics)*
-4. Cluster the forest into a handful of themes — each a story-shaped leaf made visible *(4–8 themes; SKILL.md §3)*
-5. Watch one Saturday land it: this week's exhaust → these named themes *(TBD — anchor to the live run in progress; documentary, watching it happen, NOT a stage-by-stage walkthrough)*
+4. Watch one Saturday: a ~24-PR, ~60-issue week across 13 repos — the forest, in numbers *(run of 2026-06-27)*
+5. It comes back as six named, story-shaped themes — an LLM-to-rules ratchet, the good death of a deprecated library, an Earthsea review — the leaves made visible *(4–8 themes per SKILL.md §3; four filed as kernels that morning — #287, #288, #290)*
 6. It feeds the pipeline, doesn't replace it — the kernels still go to review, craft, coauthoring *(digest builds publications, not finished posts)*
 
 ## 4. The bet — *the landing*
@@ -62,7 +62,7 @@ discovery is the filling backlog, full stop.
 
 ## Open
 
-- **Live-run grounding (scene 3, beat 5):** awaiting the output of the Saturday run in progress — fold in one or two real named themes so the turn is watched, not told. Keep it a scene, not a pipeline walkthrough.
+- **Featured themes (scene 3, beat 5):** the 2026-06-27 run surfaced six themes; I featured three for range (ratchet #287, good-death-of-a-library #288, Earthsea review #290). Swap freely — agent-readiness #289, the collection-json revival (#98 comment), or zellij-claude-pair (#227 comment) are alternates. Don't list all six; that tips into a feature tour.
 - **Title/slug:** working "The Bottleneck Isn't the Blank Page" — finalised after the prose exists (post-draft derives title from the body), not now.
 - **Scope guard:** keep on the discovery-then-publishing-bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
 - **Sources concrete vs abstract:** scene 3 names sources explicitly; confirm that's the right altitude vs. keeping "exhaust" abstract until the close.

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -6,7 +6,8 @@ Claude was always the plan. Real title settled in post-draft.
 
 Logline: the moment the bottleneck is relocated — the hard part of the
 blog was never the writing (that's coauthored with Claude); it's that the
-week is a forest I've forgotten by Friday, and the story is one leaf in it.
+week is a forest I've forgotten by Friday, and the stories worth telling are
+leaves I can't pick out of the blur.
 Opens at its opposite — the universal assumption that a blog stalls on the
 blank page and the discipline to fill it. Builds to the bet: digest solves
 *discovery* (the backlog fills), but *publishing* each kernel — review,
@@ -32,7 +33,7 @@ discovery is the filling backlog, full stop.
 2. I never planned to fill it by hand — coauthoring with Claude was the plan from the first *(premise carried from /posts/i-built-the-machine-twice)*
 3. So the page was never my problem; mine is the opposite of empty
 4. The week is a forest I've forgotten by Friday — a hundred small things that add up to something chunky, invisible one at a time *(author: I forget the week; small things sum)*
-5. Finding the one story-shaped leaf in that forest is the actual hard part *(forest/leaf)*
+5. The hard part isn't writing them up — it's seeing which ones were worth telling in the first place *(synthesis, not scarcity; zero-or-more, no count)*
 
 ## 2. The lookback I already run — *the lift*
 

--- a/outlines/the-bottleneck-isnt-the-blank-page.md
+++ b/outlines/the-bottleneck-isnt-the-blank-page.md
@@ -48,19 +48,21 @@ discovery is the filling backlog, full stop.
 2. Build the digest: fan out across the sources for one window and summarise the week *(GitHub, Readwise, Reader, Notion Media Log; link "the digest" → github.com/alunduil/blog.alunduil.com/tree/main/.claude/skills/digest)*
 3. Throw out the noise that isn't signal — squash-merge dupes, agent-branch churn *(collect.sh heuristics)*
 4. Cluster the forest into a handful of themes — each a story-shaped leaf made visible *(4–8 themes; SKILL.md §3)*
-5. It feeds the pipeline, doesn't replace it — the kernels still go to review, craft, coauthoring *(digest builds publications, not finished posts)*
+5. Watch one Saturday land it: this week's exhaust → these named themes *(TBD — anchor to the live run in progress; documentary, watching it happen, NOT a stage-by-stage walkthrough)*
+6. It feeds the pipeline, doesn't replace it — the kernels still go to review, craft, coauthoring *(digest builds publications, not finished posts)*
 
 ## 4. The bet — *the landing*
 
 1. Discovery is the solved part: I run it every Saturday, and the backlog fills in weekly waves *(51 idea issues / 46 open across 8 weeks; ~90% filed Sat–Mon — the weekend tail of a Saturday run — as of 2026-06)*
 2. Some weeks a run surfaces nothing worth keeping; usually it's more — a handful, ~60% of them arcs worth recording, filtering further from there *(author: could be zero, usually more; ~60%; too early to guess the post fill rate)*
-3. What the kernels look like — a 49-PR week braided with reading Flow; a short-game review off the media log *(#231, #250 — concrete output)*
+3. What the kernels look like — a 49-PR week braided with reading Flow; a short-game review off the media log *(link #231, #250 → their idea issues; clickable receipts)*
 4. The unsolved part is publishing: review, craft, coauthoring is the real bottleneck — and the honest reason posts actually shipped is still zero, this nearly the first *(Machine Twice #260, pub 2026-06-30)*
 5. Cheap to keep the bet open — the weekly run is fire-and-forget, value almost immediately, the tuning since is minor friction *(author)*
 6. And the bet is only as good as your exhaust — my work leaves clean logs; yours might be Todoist, a calendar, whatever trail you already leave *(author)*
 
 ## Open
 
+- **Live-run grounding (scene 3, beat 5):** awaiting the output of the Saturday run in progress — fold in one or two real named themes so the turn is watched, not told. Keep it a scene, not a pipeline walkthrough.
 - **Title/slug:** working "The Bottleneck Isn't the Blank Page" — finalised after the prose exists (post-draft derives title from the body), not now.
 - **Scope guard:** keep on the discovery-then-publishing-bottleneck angle; don't drift into architecture (#67) or the Claude-native-flow umbrella (#73).
 - **Sources concrete vs abstract:** scene 3 names sources explicitly; confirm that's the right altitude vs. keeping "exhaust" abstract until the close.

--- a/src/data/blog/the-bottleneck-isnt-the-blank-page.md
+++ b/src/data/blog/the-bottleneck-isnt-the-blank-page.md
@@ -1,0 +1,110 @@
+---
+pubDatetime: 2026-07-07T07:00:00Z
+title: The Bottleneck Isn't the Blank Page
+description: "The hard part of keeping a blog was never the writing. It was remembering what the week held and seeing which of it was worth telling."
+tags:
+  - tooling
+  - writing
+  - methodology
+---
+
+The hard part of keeping a blog is supposed to be the writing. You picture
+the blank page, the cursor blinking in an empty file late on a Sunday, the
+long hunt for something worth saying. That's the wall you brace for, the one
+people blame when a blog goes quiet.
+
+It was never my wall. From the first day I [came back to this
+blog](/posts/i-built-the-machine-twice), I meant to write these posts with
+Claude, not by myself. The blank page was a problem I handed off before I
+ever faced it.
+
+So my trouble ran the other way. It wasn't that I had nothing to say. It was
+that I had too much, and couldn't see any of it. A week of mine is a hundred
+small things: a commit here, a review there, an issue closed, a book
+finished. Each one is forgettable on its own, and by Friday I've forgotten
+most of them. Together they add up to something worth sharing. But I can't
+hold the whole untidy pile in my head long enough to find its shape.
+
+And the shape was always the hard part. Not the writing, but the seeing:
+which of those hundred small things was worth telling in the first place.
+
+I'd seen this problem before, because I'd already solved it once at work.
+There I keep a habit of looking back over the week, not to relive it but to
+find the signal in it. I look for where I made a difference, and where my
+effort went nowhere. The week already happened by the time I look. I'm not
+inventing anything. I'm reviewing something I lived but couldn't hold.
+
+It isn't only me. Ashley Willis [wrote
+about](https://github.blog/developer-skills/github/i-automated-my-job-and-it-made-me-a-better-leader/)
+wiring up the same habit: an evening "Daily Wins Recap" that gathers what she
+got done each day, so the small wins don't slip past unnoticed.
+
+The blog was the same shape of problem, pointed at a different end. If
+looking back could find my impact at work, it could find my stories here.
+
+So I built a tool to do the looking for me. The raw material was already
+there. Everything I do leaves a trace: a commit lands in a repository, a pull
+request collects a review, a line gets highlighted in whatever I'm reading, a
+book gets marked finished. The trail piles up even when I forget it. I only
+needed a way to gather it back up.
+
+I call it [the
+digest](https://github.com/alunduil/blog.alunduil.com/tree/main/.claude/skills/digest).
+Once a week it gathers everything I touched—what I did on GitHub, what I
+highlighted while reading, the books and games I marked finished—into one
+place. Then it clears out the noise: the
+duplicate commits a squash-merge leaves behind, and the churn from branches
+the agents opened and closed on their own.
+
+On Saturday, 2026-06-27, it ran across the previous seven days. The raw
+count was its own kind of answer: about two dozen pull requests and sixty-odd
+issues across thirteen repositories, plus a week of reading I'd
+half-forgotten. On Friday I couldn't have named a tenth of it.
+
+What came back wasn't the pile. It was six themes, each already shaped like a
+story. One was about [a kind of ratchet][ratchet]: let a model work out a
+messy pattern, then distil what it learned into a plain rule that runs
+without it. Another was [the quiet retirement of a small library][library]
+I'd built, deprecated once the wider ecosystem absorbed its job. A third was
+[a review][earthsea] of the Earthsea book I'd finished that week. I filed
+four of the six as kernels that same morning, the stories pulled out of the
+blur at last.
+
+The digest writes none of this. It finds it. Each theme is still only a
+kernel, a candidate, a place to start. Turning one into a post is its own
+work: the reviewing, the shaping, the long back-and-forth with Claude until
+the thing reads well to me. What it leaves me is the candidate, kept as an
+issue I can pick up and work from.
+
+So the finding works. I run the digest every Saturday, and the kernels pile
+up in weekly waves. By the time I'm writing this, fifty-one have gathered in
+the backlog, most of them filed over a weekend, forty-six still waiting their
+turn. The blank week is a solved problem. I have more to write about than I
+have time to write.
+
+Not every run is a haul. Some Saturdays it turns up nothing worth keeping.
+Most turn up a handful, and of those maybe three in five are solid enough to
+file. It's still too early to know how many of the filed ones will ever
+become posts.
+
+That's where the real wall turned out to be. Not the blank page, and not the
+finding. The writing is the slow part: the drafting, the shaping, the long
+passes until a draft is good enough to publish. The honest scoreboard shows
+it. Of those fifty-one kernels, the number that have grown into published
+posts is, so far, zero. The one you're reading is nearly the first.
+
+None of that makes me want to stop running it. The digest costs me next to
+nothing: a job that runs on its own each Saturday, and a few minutes to skim
+what it found. The finding was always going to outrun the writing. I'd rather
+carry the backlog than face the blank week.
+
+There's one catch worth naming. The digest works because I leave a trail
+worth reading. My weeks happen in public, in commits and issues and reviews,
+with the books and articles I read logged alongside. Point the same idea at
+someone whose work leaves no record and it has nothing to gather. The
+pipeline could be anyone's, but the trail has to be your own: a task list, a
+calendar, whatever you already leave behind.
+
+[ratchet]: https://github.com/alunduil/blog.alunduil.com/issues/287
+[library]: https://github.com/alunduil/blog.alunduil.com/issues/288
+[earthsea]: https://github.com/alunduil/blog.alunduil.com/issues/290

--- a/src/data/blog/the-bottleneck-isnt-the-blank-page.md
+++ b/src/data/blog/the-bottleneck-isnt-the-blank-page.md
@@ -25,14 +25,14 @@ finished. Each one is forgettable on its own, and by Friday I've forgotten
 most of them. Together they add up to something worth sharing. But I can't
 hold the whole untidy pile in my head long enough to find its shape.
 
-And the shape was always the hard part. Not the writing, but the seeing:
-which of those hundred small things was worth telling in the first place.
+And the shape was always the hard part. Not how to write a post, but how to
+find the one worth telling.
 
 I'd seen this problem before, because I'd already solved it once at work.
 There I keep a habit of looking back over the week, not to relive it but to
 find the signal in it. I look for where I made a difference, and where my
-effort went nowhere. The week already happened by the time I look. I'm not
-inventing anything. I'm reviewing something I lived but couldn't hold.
+effort went nowhere. The week already happened by the time I look. I invent
+nothing. I only review what I lived but couldn't hold.
 
 It isn't only me. Ashley Willis [wrote
 about](https://github.blog/developer-skills/github/i-automated-my-job-and-it-made-me-a-better-leader/)
@@ -42,8 +42,8 @@ got done each day, so the small wins don't slip past unnoticed.
 The blog was the same shape of problem, pointed at a different end. If
 looking back could find my impact at work, it could find my stories here.
 
-So I built a tool to do the looking for me. The raw material was already
-there. Everything I do leaves a trace: a commit lands in a repository, a pull
+So I built a tool to do it for me. The raw material was already there.
+Everything I do leaves a trace: a commit lands in a repository, a pull
 request collects a review, a line gets highlighted in whatever I'm reading, a
 book gets marked finished. The trail piles up even when I forget it. I only
 needed a way to gather it back up.
@@ -52,9 +52,9 @@ I call it [the
 digest](https://github.com/alunduil/blog.alunduil.com/tree/main/.claude/skills/digest).
 Once a week it gathers everything I touched—what I did on GitHub, what I
 highlighted while reading, the books and games I marked finished—into one
-place. Then it clears out the noise: the
-duplicate commits a squash-merge leaves behind, and the churn from branches
-the agents opened and closed on their own.
+place. Then it clears out the noise: the duplicate commits a squash-merge
+leaves behind, and the churn from branches the agents opened and closed on
+their own.
 
 On Saturday, 2026-06-27, it ran across the previous seven days. The raw
 count was its own kind of answer: about two dozen pull requests and sixty-odd
@@ -71,10 +71,10 @@ four of the six as kernels that same morning, the stories pulled out of the
 blur at last.
 
 The digest writes none of this. It finds it. Each theme is still only a
-kernel, a candidate, a place to start. Turning one into a post is its own
-work: the reviewing, the shaping, the long back-and-forth with Claude until
-the thing reads well to me. What it leaves me is the candidate, kept as an
-issue I can pick up and work from.
+kernel, a candidate, a place to start. To turn one into a post is separate
+work: the review, the revision, the long back-and-forth with Claude until it
+reads well to me. What it leaves me is the candidate, kept as an issue I can
+pick up and work from.
 
 So the finding works. I run the digest every Saturday, and the kernels pile
 up in weekly waves. By the time I'm writing this, fifty-one have gathered in
@@ -88,15 +88,15 @@ file. It's still too early to know how many of the filed ones will ever
 become posts.
 
 That's where the real wall turned out to be. Not the blank page, and not the
-finding. The writing is the slow part: the drafting, the shaping, the long
-passes until a draft is good enough to publish. The honest scoreboard shows
-it. Of those fifty-one kernels, the number that have grown into published
-posts is, so far, zero. The one you're reading is nearly the first.
+finding. The writing is the slow part, and the real bottleneck. The honest
+scoreboard shows it. Of those fifty-one kernels, the number that have grown
+into published posts is, so far, zero. The one you're reading is nearly the
+first.
 
 None of that makes me want to stop running it. The digest costs me next to
 nothing: a job that runs on its own each Saturday, and a few minutes to skim
-what it found. The finding was always going to outrun the writing. I'd rather
-carry the backlog than face the blank week.
+what it found. The finding will always outrun the writing. I'd rather carry
+the backlog than face the blank week.
 
 There's one catch worth naming. The digest works because I leave a trail
 worth reading. My weeks happen in public, in commits and issues and reviews,

--- a/src/data/blog/the-bottleneck-isnt-the-blank-page.md
+++ b/src/data/blog/the-bottleneck-isnt-the-blank-page.md
@@ -8,7 +8,7 @@ tags:
   - methodology
 ---
 
-The hard part of keeping a blog is supposed to be the writing. You picture
+The hard part of keeping a blog looks like the writing. You picture
 the blank page, the cursor blinking in an empty file late on a Sunday, the
 long hunt for something worth saying. That's the wall you brace for, the one
 people blame when a blog goes quiet.
@@ -36,14 +36,14 @@ nothing. I only review what I lived but couldn't hold.
 
 It isn't only me. Ashley Willis [wrote
 about](https://github.blog/developer-skills/github/i-automated-my-job-and-it-made-me-a-better-leader/)
-wiring up the same habit: an evening "Daily Wins Recap" that gathers what she
-got done each day, so the small wins don't slip past unnoticed.
+the same habit: an evening "Daily Wins Recap" that gathers each day's work,
+so the wins don't slip past unnoticed.
 
 The blog was the same shape of problem, pointed at a different end. If
 looking back could find my impact at work, it could find my stories here.
 
 So I built a tool to do it for me. The raw material was already there.
-Everything I do leaves a trace: a commit lands in a repository, a pull
+Everything I do leaves a trace. A commit lands in a repository, a pull
 request collects a review, a line gets highlighted in whatever I'm reading, a
 book gets marked finished. The trail piles up even when I forget it. I only
 needed a way to gather it back up.
@@ -90,7 +90,7 @@ become posts.
 That's where the real wall turned out to be. Not the blank page, and not the
 finding. The writing is the slow part, and the real bottleneck. The honest
 scoreboard shows it. Of those fifty-one kernels, the number that have grown
-into published posts is, so far, zero. The one you're reading is nearly the
+into published posts is, so far, zero. The one you're reading is one of the
 first.
 
 None of that makes me want to stop running it. The digest costs me next to


### PR DESCRIPTION
## Summary

A new post for #126: the hard part of keeping a blog was never the writing (it's co-authored with Claude) but seeing which of the week's scattered work was worth telling before it fades. The digest surfaces those story-shaped kernels every Saturday; the remaining bottleneck is publishing each one. Lands on the honest bet — discovery solved (fifty-one kernels filed), zero shipped yet, this nearly the first. Drafted from an approved outline (`outlines/the-bottleneck-isnt-the-blank-page.md`) through the post-draft pipeline.

## Gotchas

- Lands on an unproven bet by design: discovery works, publishing is the open question. Not a gap.
- Co-authoring with Claude is a plain nod threaded through, not the subject (that's #67/#73).
- Vale: `Microsoft.DateFormat` (US `Month DD, YYYY`) is disabled so prose dates match the RFC 3339 frontmatter; an enforcing replacement rule is tracked in #291. `Earthsea` added to the vocabulary.
- Also includes three `outline-draft` skill refinements the outline exposed (working-title-not-final; confirm the moment-of-change; a double-climax Diagnose signature).
- `pubDatetime` is 2026-07-07 (a tech-Tuesday, one week after Machine Twice) — future-gated, so merging accepts the work without publishing early.

## Verification

- `pre-commit run --files` (Vale + markdownlint) passes; `pnpm build` clean. No private Reader URLs in the body.

Refs #126