### PR TITLE
Add post: How I'd Recover a Box I Can't Reach (#209)

### DIFF
--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -138,6 +138,11 @@ wishlist
 cron
 hostname
 NAT'd
+systemd
+Tailscale
+filesystem
+reflash
+configs
 
 # Traditional possessive forms (singular noun ending in s + 's per
 # CMOS). Hunspell affix rules don't generate these; add each variant

--- a/outlines/how-i-recover.md
+++ b/outlines/how-i-recover.md
@@ -44,11 +44,11 @@ never executed.
 
 1. The tempting move: `rsync` the backed-up `/etc` straight over the fresh image — and that's the failure mode
 2. Wrong root `fstab` UUID → it won't boot → no SSH → box gone *(new card = new filesystem UUID)*
-3. Wrong network/interface config → no route home → box gone
+3. Networking could strand me the same way — except I run DHCP precisely so a fresh image gets a route home with nothing to merge *(a lockout risk designed out)*
 4. And the fresh image won't even be the same base as what's running now, so its `/etc` defaults differ further — more reason not to blind-copy *(reflash lands on a different base than the current upgraded one)*
-5. On a box across an ocean, those aren't inconveniences; they're unrecoverable without another on-site trip
-6. The data was never the hard part. The three-way `/etc` merge is — and remoteness makes it unforgiving
-7. The discipline: keep the *new* base image's root `fstab` UUID, hand-diff network config and hostname, `rsync` only the "safe" application configs
+5. On a box across an ocean, a break like that isn't an inconvenience; it's unrecoverable without another on-site trip
+6. The data was never the hard part. The `/etc` merge is — and remoteness makes it unforgiving
+7. So the discipline shrinks to almost one file: leave the fresh `fstab` and (thanks to DHCP) the network untouched, restore the hostname, `rsync` only the "safe" application configs
 
 ## 4. The access I didn't back up — *the twist / deepen*
 
@@ -62,11 +62,13 @@ never executed.
 1. All of this is written down; none of it is tested *(paper plan — same admission as How I Back Up)*
 2. The only real test is a real restore, and that risks bricking a working box I can't reach
 3. The distance that makes the plan worth writing is the distance that makes me refuse to run it
-4. Hands-off operation was the goal; an untested recovery plan is the tax I pay for it
+4. The better fix is future work: bake my config into a recovery image so a reflash lands closer to turnkey — smaller merge, simpler for the hands on-site *(on the list)*
+5. Hands-off operation was the goal; an untested recovery plan is the tax I pay for it
 
 ## Open
 
-- Resolved: cadence (hourly), on-site path (lay hands, physical steps only), base image (keep generic), access gap (Tailscale state, folded into scene 4).
+- Resolved: cadence (hourly), on-site path (lay hands, physical steps only), base image (keep generic), access gap (Tailscale state, folded into scene 4), networking (DHCP by design, so no network merge — scene 3), UptimeRobot heartbeat as outage alarm (scene 1).
 - Follow-up to file separately after approval: improve the DR setup so the Tailscale/remote-access substrate is captured or reproducible — the scene-4 gap. Not in scope for this post.
+- Future consideration (a quick mention in scene 5, not a section): a prebaked recovery-image build so a reflash lands turnkey. Kept light in the post; may file as its own idea issue later.
 
 [How I Back Up]: /posts/how-i-back-up

--- a/outlines/how-i-recover.md
+++ b/outlines/how-i-recover.md
@@ -65,10 +65,4 @@ never executed.
 4. The better fix is future work: bake my config into a recovery image so a reflash lands closer to turnkey — smaller merge, simpler for the hands on-site *(on the list)*
 5. Hands-off operation was the goal; an untested recovery plan is the tax I pay for it
 
-## Open
-
-- Resolved: cadence (hourly), on-site path (lay hands, physical steps only), base image (keep generic), access gap (Tailscale state, folded into scene 4), networking (DHCP by design, so no network merge — scene 3), UptimeRobot heartbeat as outage alarm (scene 1).
-- Follow-up to file separately after approval: improve the DR setup so the Tailscale/remote-access substrate is captured or reproducible — the scene-4 gap. Not in scope for this post.
-- Future consideration (a quick mention in scene 5, not a section): a prebaked recovery-image build so a reflash lands turnkey. Kept light in the post; may file as its own idea issue later.
-
 [How I Back Up]: /posts/how-i-back-up

--- a/outlines/how-i-recover.md
+++ b/outlines/how-i-recover.md
@@ -1,0 +1,71 @@
+# How I'd Recover a Box I Can't Reach — outline
+
+*Working title.* Companion to [How I Back Up]. Register: "How I…"
+methodology prose, NanoPi as the worked example, pattern generalizes to
+any remote pet Linux host.
+
+**Logline.** The one moment of change: realizing the hard part of
+recovering a remote single-board host isn't the data — `rclone` already
+has that — it's that a wrong `/etc` restore over SSH locks me out of a
+box on another continent, with only lay hands on-site and no way back
+in. The story opens at its opposite: a dead-simple, hands-off Tailscale
+exit node that just works and backs itself up every hour, so recovery
+*feels* solved. It lands on the honest limit — the plan stays untested,
+because the only way to test it is to risk bricking the working box I
+can't touch. The distance that makes the plan necessary is the same
+distance that forbids me from running it.
+
+Facts in hand: NanoPi-NEO3, Debian 12 (bookworm), single job = Tailscale
+exit node in the US Midwest; author in London; lay hands available
+on-site for physical steps only. Backup is real —
+`rclone-backup.service` + `.timer` (`OnCalendar=hourly`,
+`Persistent=true`), syncing package selections, all of `/etc`, and all
+of `/home` to `Google Drive:NanoPi-NEO3/`. Restore is a paper plan,
+never executed.
+
+## 1. The box that just works — *the opposite*
+
+1. NanoPi-NEO3: one job, a Tailscale exit node — nothing else *(single purpose)*
+2. It lives in the US Midwest; I live in London *(the distance, planted but not yet the problem)*
+3. Built for hands-off: autoupdates and Grafana Alloy telemetry so I never think about it
+4. It backs itself up every hour to Google Drive — package selections, `/etc`, `/home` *(`rclone-backup.service` + `.timer`, `OnCalendar=hourly`, `Persistent=true`; `dpkg --get-selections` + three `rclone sync` to `Google Drive:NanoPi-NEO3/`)*
+5. So I'm covered. The data is safe. Recovery feels like a solved problem.
+
+## 2. Reflash from another continent — *the complication*
+
+1. What kills it: SD-card corruption or an OS upgrade gone wrong *(bridge: why recovery ever comes up)*
+2. Either one means reflash — and I cannot touch the card *(no physical access)*
+3. I have hands on-site, but lay ones: their whole job is insert a freshly-flashed card and power it on — so the plan has to be that simple for them *(design constraint)*
+4. Everything after boot is mine over SSH — and the easy 90% comes back in a few commands: packages via `dpkg --set-selections` + `apt dselect-upgrade`, `/home` via `rclone`, Alloy reinstalled from Grafana's repo
+5. Every one of those runs on a box that will drop me the moment I get boot or networking wrong
+
+## 3. The file that locks the door — *the turn*
+
+1. The tempting move: `rsync` the backed-up `/etc` straight over the fresh image — and that's the failure mode
+2. Wrong root `fstab` UUID → it won't boot → no SSH → box gone *(new card = new filesystem UUID)*
+3. Wrong network/interface config → no route home → box gone
+4. And the fresh image won't even be the same base as what's running now, so its `/etc` defaults differ further — more reason not to blind-copy *(reflash lands on a different base than the current upgraded one)*
+5. On a box across an ocean, those aren't inconveniences; they're unrecoverable without another on-site trip
+6. The data was never the hard part. The three-way `/etc` merge is — and remoteness makes it unforgiving
+7. The discipline: keep the *new* base image's root `fstab` UUID, hand-diff network config and hostname, `rsync` only the "safe" application configs
+
+## 4. The access I didn't back up — *the twist / deepen*
+
+1. Even a clean merge leaves one thing out: the substrate that gives me remote access at all
+2. The backup syncs `/etc` and `/home` — not `/var/lib/tailscale`, so the exit node comes back with no identity *(Tailscale state isn't captured)*
+3. My fallback is to walk the lay hands through forwarding the SSH port so I can connect directly — but that only works if my key is already trusted by the box, which a reflash wipes *(the catch-22)*
+4. So regaining access is its own bootstrapping problem, and right now the weakest link — a gap I know about, on the list
+
+## 5. The plan I won't run — *the landing / honest limitation*
+
+1. All of this is written down; none of it is tested *(paper plan — same admission as How I Back Up)*
+2. The only real test is a real restore, and that risks bricking a working box I can't reach
+3. The distance that makes the plan worth writing is the distance that makes me refuse to run it
+4. Hands-off operation was the goal; an untested recovery plan is the tax I pay for it
+
+## Open
+
+- Resolved: cadence (hourly), on-site path (lay hands, physical steps only), base image (keep generic), access gap (Tailscale state, folded into scene 4).
+- Follow-up to file separately after approval: improve the DR setup so the Tailscale/remote-access substrate is captured or reproducible — the scene-4 gap. Not in scope for this post.
+
+[How I Back Up]: /posts/how-i-back-up

--- a/outlines/how-i-recover.md
+++ b/outlines/how-i-recover.md
@@ -28,12 +28,13 @@ never executed.
 1. NanoPi-NEO3: one job, a Tailscale exit node — nothing else *(single purpose)*
 2. It lives in the US Midwest; I live in London *(the distance, planted but not yet the problem)*
 3. Built for hands-off: autoupdates and Grafana Alloy telemetry so I never think about it
-4. It backs itself up every hour to Google Drive — package selections, `/etc`, `/home` *(`rclone-backup.service` + `.timer`, `OnCalendar=hourly`, `Persistent=true`; `dpkg --get-selections` + three `rclone sync` to `Google Drive:NanoPi-NEO3/`)*
-5. So I'm covered. The data is safe. Recovery feels like a solved problem.
+4. A UptimeRobot heartbeat is the outage alarm — the box checks in, and its silence is the signal, because a dead box (and its telemetry) can't report itself *(HEARTBEAT monitor "NanoPi-NEO3")*
+5. It backs itself up every hour to Google Drive — package selections, `/etc`, `/home` *(`rclone-backup.service` + `.timer`, `OnCalendar=hourly`, `Persistent=true`; `dpkg --get-selections` + three `rclone sync` to `Google Drive:NanoPi-NEO3/`)*
+6. So I'm covered. The data is safe. Recovery feels like a solved problem.
 
 ## 2. Reflash from another continent — *the complication*
 
-1. What kills it: SD-card corruption or an OS upgrade gone wrong *(bridge: why recovery ever comes up)*
+1. It goes quiet — the heartbeat stops. SD-card corruption or an OS upgrade gone wrong *(the alarm from 1.4 firing is how recovery ever comes up)*
 2. Either one means reflash — and I cannot touch the card *(no physical access)*
 3. I have hands on-site, but lay ones: their whole job is insert a freshly-flashed card and power it on — so the plan has to be that simple for them *(design constraint)*
 4. Everything after boot is mine over SSH — and the easy 90% comes back in a few commands: packages via `dpkg --set-selections` + `apt dselect-upgrade`, `/home` via `rclone`, Alloy reinstalled from Grafana's repo

--- a/outlines/how-i-recover.md
+++ b/outlines/how-i-recover.md
@@ -34,11 +34,14 @@ never executed.
 
 ## 2. Reflash from another continent — *the complication*
 
-1. It goes quiet — the heartbeat stops. SD-card corruption or an OS upgrade gone wrong *(the alarm from 1.4 firing is how recovery ever comes up)*
-2. Either one means reflash — and I cannot touch the card *(no physical access)*
-3. I have hands on-site, but lay ones: their whole job is insert a freshly-flashed card and power it on — so the plan has to be that simple for them *(design constraint)*
-4. Everything after boot is mine over SSH — and the easy 90% comes back in a few commands: packages via `dpkg --set-selections` + `apt dselect-upgrade`, `/home` via `rclone`, Alloy reinstalled from Grafana's repo
-5. Every one of those runs on a box that will drop me the moment I get boot or networking wrong
+1. The heartbeat stops — but most of the time it's mundane: a cable worked loose, or the switch it hangs off rebooted, and the box is fine once the network is back *(the common real-world outage — networking/cabling, not the card)*
+2. Even that I can't fix from London; a loose cable still waits on someone walking to the box *(remoteness bites even the trivial case)*
+3. The failures that actually need this plan are rarer — a corrupted SD card, or an upgrade gone wrong — and those mean a reflash *(the serious case; the alarm from 1.4 is how it surfaces)*
+4. Either one means reflash — and I cannot touch the card *(no physical access)*
+5. I have hands on-site, but lay ones: their whole job is insert a freshly-flashed card and power it on — so the plan has to be that simple for them *(design constraint)*
+6. Even that first step isn't solved — someone has to flash the card, and lay hands can't; the current fallback is a video-call walkthrough *(unsolved seam — card provenance)*
+7. Everything after boot is mine over SSH — and the easy 90% comes back in a few commands: packages via `dpkg --set-selections` + `apt dselect-upgrade`, `/home` via `rclone`, Alloy reinstalled from Grafana's repo
+8. Every one of those runs on a box that will drop me the moment I get boot or networking wrong
 
 ## 3. The file that locks the door — *the turn*
 

--- a/src/data/blog/how-i-recover.md
+++ b/src/data/blog/how-i-recover.md
@@ -1,0 +1,127 @@
+---
+pubDatetime: 2026-07-28T08:00:00+01:00
+title: "How I'd Recover a Box I Can't Reach"
+description: "A Tailscale exit node backs itself up hourly, but recovering it from another continent is a paper plan; the hard part is the configuration merge, not the data."
+tags:
+  - disaster-recovery
+  - methodology
+  - homelab
+---
+
+Somewhere in the American Midwest, a NanoPi-NEO3 runs one service and
+nothing else. It's a [Tailscale][tailscale] exit node—the box that lets
+my traffic surface on a US address when I need it to—and that's its whole
+life. I built it to be forgotten. Unattended upgrades keep it patched, a
+[Grafana Alloy][alloy] agent ships its metrics somewhere I can glance at
+them, and for months at a stretch I don't think about it at all.
+
+I live in London. For almost everything the box does, the ocean between
+us is a detail that never comes up.
+
+What tells me something is wrong is silence. [UptimeRobot][uptimerobot]
+watches for a heartbeat on a schedule, and when the check-ins stop, it
+pages me. The monitor has to run off the box: a dead box can't report its
+own failure, and neither can the telemetry running on it.
+
+Every hour, the box also backs itself up. A systemd timer fires an
+[`rclone`][rclone] job that pushes three things into a corner of my
+Google Drive: the list of every installed package, the whole of `/etc`,
+and the whole of `/home`. Configuration, package selection, and my
+files—everything a working system is made of, copied off the board and
+out of the house before anything can happen to the card it lives on.
+
+So I'm covered. The data is safe, an hour old at worst, sitting somewhere
+I trust. Recovery, if it ever came to it, felt like a problem I'd already
+solved.
+
+Then the heartbeat stops. Two things end this box: an SD card that has
+quietly corrupted itself, or an upgrade that went in wrong and won't boot
+again. Either way the fix is the same, and it starts with a new card.
+
+That's the first problem, because I can't touch the card. The people I
+have on-site are willing but not technical. What I can ask of them is
+small and physical: take out the old card, put in one that boots, and
+power the board back on. Everything after that has to come from me, over
+SSH, from another continent. So the plan has to work at that distance. It
+has to ask little of the hands at one end and forgive me at the other.
+
+Once the box boots, most of the recovery is quick. A saved list of package
+selections goes back with `dpkg --set-selections` and an `apt` pass to
+pull them in. `/home` comes down from Google Drive with the same `rclone`
+that put it there. Grafana Alloy isn't in Debian's archives, so it gets
+reinstalled from Grafana's own repository. Nine-tenths of the box comes
+back in a handful of commands, and none of it is where the risk lives.
+
+The risk lives in the last tenth. There is a next move that suggests
+itself, and it is the wrong one. My backup has the whole of `/etc`, every configuration
+file the running system had, so the temptation is to `rsync` it straight
+back over the fresh image and be done. That is the failure mode.
+
+The trap is `/etc/fstab`, the file that names which disk to mount as the
+root. A freshly flashed card has a new filesystem with a new UUID, and
+the base image's `fstab` already points at it. My backed-up `fstab`
+points at the old card's UUID, which no longer exists. Copy it over and
+the box can't find its root on the next boot. It won't come up, I won't
+get an SSH prompt, and the only fix is a pair of hands in the Midwest.
+
+Networking could strand me the same way. A wrong interface name or a
+stale static address, and there is no route home. I took that failure off
+the table on purpose: the box uses DHCP. Whatever the fresh image calls
+its interface, it asks the network for an address and gets one, and I can
+reach it. There is no network configuration to merge, because I chose not
+to have any.
+
+It gets touchier still. The card I reflash to probably won't be the same
+base image the box runs now. I built the current one from the vendor's
+default and upgraded it by hand, and a rebuild would likely start from a
+different image. Its defaults in `/etc` will differ from mine in ways I
+can't fully predict. That is one more reason a blind copy is reckless.
+
+So the real work is smaller than it looks. The data was never the hard
+part; `rclone` has all of it. The hard part is `/etc`, and on a box an
+ocean away a wrong file there is not an inconvenience. It is a second
+trip I have to arrange from London. The discipline comes down to almost a
+single file: leave the fresh image's `fstab` alone, let DHCP keep me on
+the network, copy the hostname back, and `rsync` only the application
+configs that are safe to restore.
+
+There is a hole in all of this that a clean `/etc` merge doesn't close.
+The thing that lets me reach the box at all is Tailscale, and Tailscale's
+identity for this node lives in `/var/lib/tailscale`, which my backup
+never touches. It syncs `/etc` and `/home` and nothing else. So even a
+perfect restore brings the exit node back with no idea who it is on my
+network. I would have to re-authenticate it before it is an exit node
+again, and before I can reach it the usual way.
+
+The fallback is uglier than I'd like. I can talk the people on-site
+through forwarding the SSH port on the router, so I connect straight to
+the box over the internet with no Tailscale in the way. But that only
+works if my key is already trusted by the machine I'm connecting to, and
+a fresh image is exactly the machine that hasn't been told to trust it
+yet. The way back in depends on the access I'm trying to restore. I don't
+have a clean answer for that yet; it's the weakest link, and it's on the
+list.
+
+Every step of this is written down, and not one of it has been run. It's
+a plan on paper, and I know why it stays that way. The only real test is
+a real restore: wipe the card, flash it, and walk the whole sequence on
+the live hardware. But the live hardware is a working exit node I depend
+on, sitting where I can't get to it. To prove the recovery works I'd have
+to break the thing I'm protecting, on a box I can't reach if the proof
+goes wrong. The distance that makes this plan worth writing is the
+distance that keeps me from testing it.
+
+There is a better version waiting to be built. If I baked my
+configuration into the image itself, so a rebuild started from a card
+that already knew how to be this box, the merge would shrink toward
+nothing and the job at the far end would get simpler for the people doing
+it. That's the direction. I haven't built it yet.
+
+For now I have hourly backups I trust and a recovery I've never
+rehearsed. Hands-off was always the point of this box; an untested plan
+for the day it isn't is the tax I pay for the quiet.
+
+[tailscale]: https://tailscale.com/
+[alloy]: https://grafana.com/docs/alloy/latest/
+[uptimerobot]: https://uptimerobot.com/
+[rclone]: https://rclone.org/

--- a/src/data/blog/how-i-recover.md
+++ b/src/data/blog/how-i-recover.md
@@ -34,7 +34,14 @@ So I'm covered. The data is safe, an hour old at worst, sitting somewhere
 I trust. Recovery, if it ever came to it, felt like a problem I'd already
 solved.
 
-Then the heartbeat stops. Two things end this box: an SD card that has
+Then the heartbeat stops. Most of the time it's nothing dramatic: a cable
+has worked loose, or the switch the box hangs off has rebooted, and the
+box is fine again the moment the network comes back. For all the planning
+that follows, the usual thing that takes this box down is a cable, not the
+card. And even that I can't fix from London—a loose cable waits on someone
+walking over to the board.
+
+The failures that actually need a plan are rarer: an SD card that has
 quietly corrupted itself, or an upgrade that went in wrong and won't boot
 again. Either way the fix is the same, and it starts with a new card.
 

--- a/src/data/blog/how-i-recover.md
+++ b/src/data/blog/how-i-recover.md
@@ -4,7 +4,7 @@ title: "How I'd Recover a Box I Can't Reach"
 description: "A Tailscale exit node backs itself up hourly, but recovering it from another continent is a paper plan; the hard part is the configuration merge, not the data."
 tags:
   - disaster-recovery
-  - methodology
+  - backups
   - homelab
 ---
 
@@ -45,6 +45,10 @@ power the board back on. Everything after that has to come from me, over
 SSH, from another continent. So the plan has to work at that distance. It
 has to ask little of the hands at one end and forgive me at the other.
 
+Even that first step isn't fully solved. Someone has to flash the card,
+and the hands I have can't. The best answer I have right now is to walk
+them through it on a video call, which is its own kind of fragile.
+
 Once the box boots, most of the recovery is quick. A saved list of package
 selections goes back with `dpkg --set-selections` and an `apt` pass to
 pull them in. `/home` comes down from Google Drive with the same `rclone`
@@ -53,9 +57,10 @@ reinstalled from Grafana's own repository. Nine-tenths of the box comes
 back in a handful of commands, and none of it is where the risk lives.
 
 The risk lives in the last tenth. There is a next move that suggests
-itself, and it is the wrong one. My backup has the whole of `/etc`, every configuration
-file the running system had, so the temptation is to `rsync` it straight
-back over the fresh image and be done. That is the failure mode.
+itself, and it is the wrong one. My backup has the whole of `/etc`, every
+configuration file the running system had, so the temptation is to
+`rsync` it straight back over the fresh image and be done. That is the
+failure mode.
 
 The trap is `/etc/fstab`, the file that names which disk to mount as the
 root. A freshly flashed card has a new filesystem with a new UUID, and

--- a/src/data/blog/how-i-recover.md
+++ b/src/data/blog/how-i-recover.md
@@ -1,7 +1,7 @@
 ---
 pubDatetime: 2026-07-28T08:00:00+01:00
 title: "How I'd Recover a Box I Can't Reach"
-description: "A Tailscale exit node backs itself up hourly, but recovering it from another continent is a paper plan; the hard part is the configuration merge, not the data."
+description: "The data was never the hard part. Recovering a Linux box I run from another continent is a plan I've never dared to run, and the risk lives in one configuration file."
 tags:
   - disaster-recovery
   - backups

--- a/src/data/blog/how-i-recover.md
+++ b/src/data/blog/how-i-recover.md
@@ -37,9 +37,9 @@ solved.
 Then the heartbeat stops. Most of the time it's nothing dramatic: a cable
 has worked loose, or the switch the box hangs off has rebooted, and the
 box is fine again the moment the network comes back. For all the planning
-that follows, the usual thing that takes this box down is a cable, not the
-card. And even that I can't fix from London—a loose cable waits on someone
-walking over to the board.
+that follows, the thing that takes this box down is usually the cable, not
+a corrupted SD card. And even that I can't fix from London—a loose cable
+waits on someone walking over to the board.
 
 The failures that actually need a plan are rarer: an SD card that has
 quietly corrupted itself, or an upgrade that went in wrong and won't boot

--- a/src/data/blog/how-i-recover.md
+++ b/src/data/blog/how-i-recover.md
@@ -28,7 +28,7 @@ Every hour, the box also backs itself up. A systemd timer fires an
 Google Drive: the list of every installed package, the whole of `/etc`,
 and the whole of `/home`. Configuration, package selection, and my
 files—everything a working system is made of, copied off the board and
-out of the house before anything can happen to the card it lives on.
+out of the house before anything can happen to the SD card it lives on.
 
 So I'm covered. The data is safe, an hour old at worst, sitting somewhere
 I trust. Recovery, if it ever came to it, felt like a problem I'd already
@@ -38,7 +38,7 @@ Then the heartbeat stops. Most of the time it's nothing dramatic: a cable
 has worked loose, or the switch the box hangs off has rebooted, and the
 box is fine again the moment the network comes back. For all the planning
 that follows, the thing that takes this box down is usually the cable, not
-a corrupted SD card. And even that I can't fix from London—a loose cable
+the card. And even that I can't fix from London—a loose cable
 waits on someone walking over to the board.
 
 The failures that actually need a plan are rarer: an SD card that has


### PR DESCRIPTION
## Summary

Adds the post *How I'd Recover a Box I Can't Reach* — a methodology piece
on disaster recovery for a remote single-board host (a Tailscale exit
node run from London, hosted in the US Midwest), where the hard part
turns out to be the `/etc` configuration merge, not the data. Companion
to [How I Back Up](https://blog.alunduil.com/posts/how-i-back-up).
Includes the approved scene outline it was drafted from.

## Gotchas

- Publication is date-gated, not draft-flagged: `pubDatetime` is
  `2026-07-28` (a future Tuesday). Merging accepts the editorial work;
  the future date defers publication via `SITE.scheduledPostMargin`.
- The recovery plan is deliberately, honestly untested — that's the
  post's landing, author-confirmed, not a gap to fix. The backup half is
  real and running; the restore half is a paper plan.

Closes #209