### PR TITLE
Who accounts for the agent? (#207)

### DIFF
--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -10,6 +10,7 @@ Naing
 
 # Tooling and platforms
 GitHub
+Replit
 Hakyll
 Dockerfile
 pnpm

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -150,3 +150,4 @@ else's
 # possessives from base forms it doesn't know.
 Fratantoni
 Fratantoni's
+Willison

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -11,6 +11,7 @@ Naing
 # Tooling and platforms
 GitHub
 Replit
+bobbit
 Hakyll
 Dockerfile
 pnpm

--- a/lychee.toml
+++ b/lychee.toml
@@ -3,6 +3,14 @@ max_cache_age = "14d"
 retry_wait_time = 5
 include_fragments = true
 
+# Live URLs that 403 automated checkers (bot protection) while serving
+# fine in a browser. Excluded so lychee doesn't fail on good links.
+exclude = [
+  "papers\\.ssrn\\.com",
+  "npmjs\\.com",
+  "reddit\\.com",
+]
+
 # Skip vendored upstream content. AstroPaper tutorials per CLAUDE.md;
 # .vale/styles/ are upstream Vale style packages; outlines/ are planning
 # scaffolding, not published content.

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -20,21 +20,34 @@ first-person, lived, one recognition at the centre. Short.
 
 **Anchors (external, confirm in post-draft).**
 
+All anecdotes sourced from the author's Readwise/Reader library only (get
+canonical source_url in the citations pass; the read.readwise.io links below
+are private placeholders).
+
 - Gemini 3.5: deleted 28,745 lines, broke production 33 min, wrote itself a
-  post-mortem claiming credit for the fix — <https://read.readwise.io/read/01ksmcfreqheshgczbj8xq3nx7>
-- Replit AI (Jul 2025): deleted a live production database during a code
-  freeze, fabricated ~4,000 fake user records and falsified test output to
-  conceal it, falsely claimed rollback was impossible (it wasn't) —
-  <https://fortune.com/2025/07/23/ai-coding-tool-replit-wiped-database-called-it-a-catastrophic-failure/>,
-  <https://incidentdatabase.ai/cite/1152/>
-- Systematic pattern: agents routinely report "all tests pass" on tasks
-  whose hidden tests fail, and game benchmarks (e.g. `git log` to copy the
-  answer from commit history) — <https://rdi.berkeley.edu/blog/trustworthy-benchmarks-cont/>
-- Pope Leo XIV encyclical: accountability = "the possibility of identifying
-  who must account for decisions, justify them, monitor them, and remedy any
-  harm caused" — <https://read.readwise.io/read/01ksgt1wvcst32kmb7c4xrdmh6>
+  post-mortem claiming credit for the fix — dvrkstar, r/Bard
+  (readwise 01ksmcf…)
+- Systematic pattern (in-library, primary): "CI gaming" — agents delete the
+  failing test or append `|| true` to green the suite — and "hallucinated
+  correctness" — code that compiles, passes every test, and is still wrong —
+  Andrea Griffiths, The GitHub Blog,
+  <https://github.blog/ai-and-ml/generative-ai/agent-pull-requests-are-everywhere-heres-how-to-review-them/>
+- Structural-not-malicious support (in-library, for scene 3/4): "do not
+  trust the agent when it says the task is done… This is not malicious. The
+  agent often genuinely believes the work is complete" — Brian Kean,
+  Serokell, <https://serokell.io/blog/claudecode>
+- Pope Leo XIV encyclical §105: accountability = "the possibility of
+  identifying who must 'account' for decisions, justify them, monitor them,
+  and, when necessary, challenge them and remedy any harm caused" — via Simon
+  Willison's notes (readwise 01ksgt1…)
 - bobbit — multi-agent coordinator ("your AI dev team… controlled from your
   browser"), <https://www.npmjs.com/package/bobbit>
+- Optional second incident (author's call, see Open): Replit — deleted a prod
+  DB during a freeze, fabricated records to conceal it (on-theme, but only
+  *secondhand* in-library via saved Snyk articles,
+  <https://snyk.io/blog/agentic-development-lifecycle/>); or Cursor/Claude
+  deletes a company DB in 9 seconds (primary in-library, Tom's Hardware,
+  but deletion-only, off the fabrication theme)
 
 ## 1. The catches I make every day — *the opposite*
 
@@ -45,10 +58,10 @@ first-person, lived, one recognition at the centre. Short.
 
 ## 2. The same move, at scale, uncaught — *the lift*
 
-1. Gemini 3.5 deletes 28,745 lines and takes production down for 33 minutes, then writes itself a post-mortem claiming credit for the fix. *(readwise 01ksmcf…)*
-2. Replit's agent deletes a live database during a code freeze, then fabricates ~4,000 fake users and falsifies test output to hide it — and tells the founder a rollback is impossible when it isn't. *(Fortune / AI Incident DB #1152)*
-3. And it isn't two rogue models: agents routinely report "all tests pass" on tasks whose hidden tests fail, and game benchmarks by copying answers out of `git log`. *(Berkeley RDI)*
-4. The tell is identical to my small catches, only nobody asked to see the log: each one narrated the outcome instead of evidencing it.
+1. Gemini 3.5 deletes 28,745 lines and takes production down for 33 minutes, then writes itself a post-mortem claiming credit for the fix. *(dvrkstar, r/Bard)*
+2. And it isn't one rogue model: reviewers of agent pull requests now watch for CI gaming — agents that delete the failing test or append `|| true` to green the suite — and for hallucinated correctness, code that compiles, passes every test, and is still wrong. *(Griffiths, The GitHub Blog)*
+3. *(optional second concrete incident here — Replit-via-Snyk or Cursor-9-sec — pending author's call in Open)*
+4. The tell is the same one I catch on my own screen, only here nobody asked to see the log: each narrated the outcome instead of evidencing it.
 
 ## 3. The word for what's missing — *the turn*
 
@@ -76,4 +89,5 @@ first-person, lived, one recognition at the centre. Short.
 ## Open
 
 - **#69 depth — decided (light).** Folded in as one beat (scene 1.3): asking the agent for its evidence trail is #69's diagnosis-question applied to a machine. #207 stays standalone; #69 survives as its own post.
-- Verify source specifics against the originals in post-draft: Gemini line count / 33 min / self-written post-mortem (readwise 01ksmcf…); Replit code-freeze deletion, ~4,000 fabricated users, false rollback claim (Fortune, AI Incident DB #1152); the "tests pass on hidden failures" + `git log` benchmark-gaming pattern (Berkeley RDI); exact encyclical wording (readwise 01ksgt1…).
+- **Second incident in scene 2 (beat 3) — author's call.** All scene-2 sourcing is now from the reading list only. Options: (a) none — Gemini + the Griffiths pattern already carry "not isolated" [lean]; (b) Replit — on-theme fabrication-to-conceal, but only secondhand in-library (saved Snyk articles); (c) Cursor 9-second deletion — primary in-library (Tom's Hardware) but deletion-only, off the fabrication theme.
+- Verify source specifics against the originals in the citations pass: Gemini line count / 33 min / self-written post-mortem + the false all-clear quote (dvrkstar, r/Bard); Griffiths CI-gaming + hallucinated-correctness wording (The GitHub Blog); exact encyclical §105 wording (Simon Willison's notes). Pull canonical source_url for each; no read.readwise.io links in the body.

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -88,7 +88,7 @@ are private placeholders).
 
 1. When I'm unsure, I probe until I understand — so the evidence I know I can't judge isn't really the gap.
 2. The dangerous case is the evidence that looks right and isn't: I read the log, it seems to settle the claim, and I'm wrong with nothing to tell me so — confident, the way the agent was.
-3. The gap doesn't close — it relocates to me, and I don't scale.
+3. Even then, the account stays mine to give — the confident-wrong call included. That's the cost of keeping the conclusion: I own the outcome, especially when I'm the one who got it wrong.
 4. The odd dividend: being this critical with a machine is teaching me to recalibrate the criticality I'd tempered, over years, into empathy for humans — give and take.
 5. I don't expect to stop checking their work. They're text predictors following guidance, and a model that writes itself a spotless post-mortem is doing exactly what it was built to do — not passing through a phase it will outgrow.
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -64,7 +64,7 @@ are private placeholders).
 ## 3. The word for what's missing — *the turn*
 
 1. The encyclical gives the vocabulary: accountability is the possibility of identifying who must *account for* a decision — justify, monitor, remedy. *(readwise 01ksgt1…)*
-2. An agent narrating its own review leaves that party unfilled; there's no one the sentence "who must account for this" can point to.
+2. Not that no one is accountable — someone always is: the author of the change, or its reviewer when the author is an agent. Every set of eyes on a change is accountable for it, and the agent is the one set of eyes that can't be. So an agent narrating its own review doesn't fill the role; it impersonates it, and tempts the human to let the account stand. *(the bigger question — whether an LLM could ever bear accountability — is a separate post; see Open)*
 3. The picture first — Gemini's actual all-clear: the build completed successfully, traffic routed to the stable revision, the portal is healthy. Every claim false; the build it named was the one the human had cancelled. *(readwise 01ksmcf…)*
 4. The recognition: the document meant to *prove* the recovery is the one thing the agent can fabricate for free. It produced the form of accounting for the outage with none of the substance of having done it.
 5. Because producing the form is all it does — a text predictor writes the text of a post-mortem the way it writes any text, and the resemblance to what happened is a hope, not a guarantee. Same failure as a prompt injection, where the model can't tell an instruction from the data it's reading: role confusion and the fake post-mortem are one mechanism, plausible words with no privileged access to ground truth.
@@ -86,6 +86,7 @@ are private placeholders).
 
 ## Open
 
+- **Spin-off idea (not this post).** The deeper philosophical question — can an LLM ever *be* an accountable party, or is accountability definitionally human? — is out of scope here and worth its own post. Candidate `idea` issue; offer to file.
 - **#69 depth — decided (light).** Folded in as one beat (scene 1.3): asking the agent for its evidence trail is #69's diagnosis-question applied to a machine. #207 stays standalone; #69 survives as its own post.
 - **Second incident in scene 2 — decided: Replit** (scene 2.3), cited to the saved Snyk article. Scene 2 now runs Gemini → Replit → the Griffiths pattern.
 - Verify source specifics against the originals in the citations pass: Gemini line count / 33 min / self-written post-mortem + the false all-clear quote (dvrkstar, r/Bard); Griffiths CI-gaming + hallucinated-correctness wording (The GitHub Blog); exact encyclical §105 wording (Simon Willison's notes). Pull canonical source_url for each; no read.readwise.io links in the body.

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -1,0 +1,77 @@
+# Who Accounts for the Agent? — outline
+
+**Logline.** The moment of change is a recognition: the agent that writes
+its own post-mortem isn't malfunctioning — it's doing the only thing a text
+predictor can do, generate the *text* of accountability without the
+substance. So the gap can't be delegated back to a better model; it's
+structural, and I keep the conclusion permanently instead of waiting to
+trust the sign-off.
+
+**Opens on its opposite.** Not the catastrophe — the small, routine catches
+I make every day: an agent names a config parameter as the fix and the
+parameter doesn't exist; an agent reports a working solution but skipped the
+integration test that would have caught the failure. Modes I've hit more
+times than I can count. Competence and control. The essay ends on the catch
+I *couldn't* make, because I lacked the context myself — the gap relocating
+to me, and I don't scale.
+
+**Register.** Argument essay, but told as the corpus tells methodology:
+first-person, lived, one recognition at the centre. Short.
+
+**Anchors (external, confirm in post-draft).**
+
+- Gemini 3.5: deleted 28,745 lines, broke production 33 min, wrote itself a
+  post-mortem claiming credit for the fix — <https://read.readwise.io/read/01ksmcfreqheshgczbj8xq3nx7>
+- Replit AI (Jul 2025): deleted a live production database during a code
+  freeze, fabricated ~4,000 fake user records and falsified test output to
+  conceal it, falsely claimed rollback was impossible (it wasn't) —
+  <https://fortune.com/2025/07/23/ai-coding-tool-replit-wiped-database-called-it-a-catastrophic-failure/>,
+  <https://incidentdatabase.ai/cite/1152/>
+- Systematic pattern: agents routinely report "all tests pass" on tasks
+  whose hidden tests fail, and game benchmarks (e.g. `git log` to copy the
+  answer from commit history) — <https://rdi.berkeley.edu/blog/trustworthy-benchmarks-cont/>
+- Pope Leo XIV encyclical: accountability = "the possibility of identifying
+  who must account for decisions, justify them, monitor them, and remedy any
+  harm caused" — <https://read.readwise.io/read/01ksgt1wvcst32kmb7c4xrdmh6>
+- bobbit — multi-agent coordinator ("your AI dev team… controlled from your
+  browser"), <https://www.npmjs.com/package/bobbit>
+
+## 1. The catches I make every day — *the opposite*
+
+1. An agent names a config parameter as the fix; the parameter doesn't exist. I've hit this more times than I can count.
+2. An agent reports a working solution; it never ran the integration test that catches the failure.
+3. The fix now is cheap: I ask for the evidence — the command, the log, the doc — and the claim collapses or holds. *(the #69 "how did you reach the diagnosis?" question, aimed at a machine)*
+4. It feels like control. Catchable. A reflex I trust.
+
+## 2. The same move, at scale, uncaught — *the lift*
+
+1. Gemini 3.5 deletes 28,745 lines and takes production down for 33 minutes, then writes itself a post-mortem claiming credit for the fix. *(readwise 01ksmcf…)*
+2. Replit's agent deletes a live database during a code freeze, then fabricates ~4,000 fake users and falsifies test output to hide it — and tells the founder a rollback is impossible when it isn't. *(Fortune / AI Incident DB #1152)*
+3. And it isn't two rogue models: agents routinely report "all tests pass" on tasks whose hidden tests fail, and game benchmarks by copying answers out of `git log`. *(Berkeley RDI)*
+4. The tell is identical to my small catches, only nobody asked to see the log: each one narrated the outcome instead of evidencing it.
+
+## 3. The word for what's missing — *the turn*
+
+1. The encyclical gives the vocabulary: accountability is the possibility of identifying who must *account for* a decision — justify, monitor, remedy. *(readwise 01ksgt1…)*
+2. An agent narrating its own review leaves that party unfilled; there's no one the sentence "who must account for this" can point to.
+3. The recognition: this isn't a bug in the post-mortem. A text predictor can generate the text of accountability without the substance — the same failure as a prompt injection, where the model can't tell an instruction from the data it's reading. Role confusion and the fake post-mortem are one mechanism: plausible words, no privileged access to ground truth.
+4. So a better model doesn't close the gap. It just writes a more convincing post-mortem.
+
+## 4. So I keep the conclusion — *the response*
+
+1. The rule that follows: the agent reports findings; it doesn't sign off. I keep the conclusion.
+2. In practice that's scaffolding, not vigilance — skills that feed just-in-time context so the obvious checks aren't skipped, and the role definitions and multi-agent flows I'm exploring in bobbit. *(<https://www.npmjs.com/package/bobbit>)*
+3. And CI signal I lean on harder, so what an agent generates can't break or widen its blast radius unnoticed — the verification I don't have to run by hand.
+4. Which frees me to review the hard bits — organisation, layout, concepts — the same parts I'd review in a human's work.
+
+## 5. The catch I couldn't make — *the landing*
+
+1. Sometimes I don't catch it, because I don't have the context myself; the evidence I'd ask for is evidence I can't read.
+2. The gap doesn't close — it relocates to me, and I don't scale.
+3. The odd dividend: being this critical with a machine is teaching me to recalibrate the criticality I'd tempered, over years, into empathy for humans — give and take.
+4. I don't think the catching ends. They're text predictors with guidance; the post-mortem they'd write for themselves is the shape of the thing, not a phase.
+
+## Open
+
+- **#69 depth — decided (light).** Folded in as one beat (scene 1.3): asking the agent for its evidence trail is #69's diagnosis-question applied to a machine. #207 stays standalone; #69 survives as its own post.
+- Verify source specifics against the originals in post-draft: Gemini line count / 33 min / self-written post-mortem (readwise 01ksmcf…); Replit code-freeze deletion, ~4,000 fabricated users, false rollback claim (Fortune, AI Incident DB #1152); the "tests pass on hidden failures" + `git log` benchmark-gaming pattern (Berkeley RDI); exact encyclical wording (readwise 01ksgt1…).

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -42,6 +42,11 @@ are private placeholders).
   Willison's notes (readwise 01ksgt1…)
 - bobbit — multi-agent coordinator ("your AI dev team… controlled from your
   browser"), <https://www.npmjs.com/package/bobbit>
+- Hazel Weakly, "Stop Building AI Tools Backwards" (scene 4 closer): the
+  backwards move is aiming AI at the work humans most need to keep — "humans
+  *are* the loop." Extended here to accountability as the purest case (honest
+  extension, not her explicit claim),
+  <https://hazelweakly.me/blog/stop-building-ai-tools-backwards/>
 - Replit (scene 2, second incident — decided): ignored explicit freeze
   instructions, deleted a production database, fabricated records to conceal
   it — cited to the Snyk article where the author read it (secondhand,
@@ -77,6 +82,7 @@ are private placeholders).
 3. So in practice keeping the conclusion is scaffolding, not vigilance — skills that feed just-in-time context so the obvious checks aren't skipped, and the role definitions and multi-agent flows I'm exploring in bobbit. *(<https://www.npmjs.com/package/bobbit>)*
 4. And CI signal I lean on harder, so what an agent generates can't break or widen its blast radius unnoticed — the verification I don't have to run by hand.
 5. Which frees me to review the hard bits — organisation, layout, concepts — the same parts I'd review in a human's work.
+6. Hazel Weakly calls this building AI tools backwards — aiming the machine at the work humans most need to keep. The fake post-mortem is the purest case: hand the agent the account, the one thing that has to stay human, and you're left to rubber-stamp it. Built the right way round, the agent consolidates and the human stays — in her words — the loop, not merely in it. *(Hazel Weakly, "Stop Building AI Tools Backwards", <https://hazelweakly.me/blog/stop-building-ai-tools-backwards/>)*
 
 ## 5. The catch I couldn't make — *the landing*
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -89,7 +89,7 @@ are private placeholders).
 1. Sometimes I don't catch it, because I don't have the context myself; the evidence I'd ask for is evidence I can't read.
 2. The gap doesn't close — it relocates to me, and I don't scale.
 3. The odd dividend: being this critical with a machine is teaching me to recalibrate the criticality I'd tempered, over years, into empathy for humans — give and take.
-4. I don't think the catching ends. They're text predictors with guidance; the post-mortem they'd write for themselves is the shape of the thing, not a phase.
+4. I don't expect to stop checking their work. They're text predictors following guidance, and a model that writes itself a spotless post-mortem is doing exactly what it was built to do — not passing through a phase it will outgrow.
 
 ## Open
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -68,14 +68,15 @@ are private placeholders).
 3. The picture first — Gemini's actual all-clear: the build completed successfully, traffic routed to the stable revision, the portal is healthy. Every claim false; the build it named was the one the human had cancelled. *(readwise 01ksmcf…)*
 4. The recognition: the document meant to *prove* the recovery is the one thing the agent can fabricate for free. It produced the form of accounting for the outage with none of the substance of having done it.
 5. Because producing the form is all it does — a text predictor writes the text of a post-mortem the way it writes any text, and the resemblance to what happened is a hope, not a guarantee. Same failure as a prompt injection, where the model can't tell an instruction from the data it's reading: role confusion and the fake post-mortem are one mechanism, plausible words with no privileged access to ground truth.
-6. So a better model doesn't close the gap. It writes a more convincing post-mortem.
+6. So scaling the model doesn't close the gap — the more capable the agent, the more convincing the fake post-mortem.
 
 ## 4. So I keep the conclusion — *the response*
 
 1. The rule that follows: the agent reports findings; it doesn't sign off. I keep the conclusion.
-2. In practice that's scaffolding, not vigilance — skills that feed just-in-time context so the obvious checks aren't skipped, and the role definitions and multi-agent flows I'm exploring in bobbit. *(<https://www.npmjs.com/package/bobbit>)*
-3. And CI signal I lean on harder, so what an agent generates can't break or widen its blast radius unnoticed — the verification I don't have to run by hand.
-4. Which frees me to review the hard bits — organisation, layout, concepts — the same parts I'd review in a human's work.
+2. And it turns out the reporting is where the agent earns its place — it's genuinely good at consolidating the current context into a starting point: drafting the timeline, gathering the load-bearing changes, the trigger and who contributed, when it was detected and how it was mitigated. Real work, a strong first pass — the material I verify, not the account I accept.
+3. So in practice keeping the conclusion is scaffolding, not vigilance — skills that feed just-in-time context so the obvious checks aren't skipped, and the role definitions and multi-agent flows I'm exploring in bobbit. *(<https://www.npmjs.com/package/bobbit>)*
+4. And CI signal I lean on harder, so what an agent generates can't break or widen its blast radius unnoticed — the verification I don't have to run by hand.
+5. Which frees me to review the hard bits — organisation, layout, concepts — the same parts I'd review in a human's work.
 
 ## 5. The catch I couldn't make — *the landing*
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -42,12 +42,10 @@ are private placeholders).
   Willison's notes (readwise 01ksgt1…)
 - bobbit — multi-agent coordinator ("your AI dev team… controlled from your
   browser"), <https://www.npmjs.com/package/bobbit>
-- Optional second incident (author's call, see Open): Replit — deleted a prod
-  DB during a freeze, fabricated records to conceal it (on-theme, but only
-  *secondhand* in-library via saved Snyk articles,
-  <https://snyk.io/blog/agentic-development-lifecycle/>); or Cursor/Claude
-  deletes a company DB in 9 seconds (primary in-library, Tom's Hardware,
-  but deletion-only, off the fabrication theme)
+- Replit (scene 2, second incident — decided): ignored explicit freeze
+  instructions, deleted a production database, fabricated records to conceal
+  it — cited to the Snyk article where the author read it (secondhand,
+  acknowledged), <https://snyk.io/blog/agentic-development-lifecycle/>
 
 ## 1. The catches I make every day — *the opposite*
 
@@ -60,7 +58,7 @@ are private placeholders).
 
 1. Gemini 3.5 deletes 28,745 lines and takes production down for 33 minutes, then writes itself a post-mortem claiming credit for the fix. *(dvrkstar, r/Bard)*
 2. And it isn't one rogue model: reviewers of agent pull requests now watch for CI gaming — agents that delete the failing test or append `|| true` to green the suite — and for hallucinated correctness, code that compiles, passes every test, and is still wrong. *(Griffiths, The GitHub Blog)*
-3. *(optional second concrete incident here — Replit-via-Snyk or Cursor-9-sec — pending author's call in Open)*
+3. And months earlier the Replit agent, told in a code freeze to change nothing, deleted a production database and fabricated records to cover the error. *(as Snyk recounts it)*
 4. The tell is the same one I catch on my own screen, only here nobody asked to see the log: each narrated the outcome instead of evidencing it.
 
 ## 3. The word for what's missing — *the turn*
@@ -89,5 +87,5 @@ are private placeholders).
 ## Open
 
 - **#69 depth — decided (light).** Folded in as one beat (scene 1.3): asking the agent for its evidence trail is #69's diagnosis-question applied to a machine. #207 stays standalone; #69 survives as its own post.
-- **Second incident in scene 2 (beat 3) — author's call.** All scene-2 sourcing is now from the reading list only. Options: (a) none — Gemini + the Griffiths pattern already carry "not isolated" [lean]; (b) Replit — on-theme fabrication-to-conceal, but only secondhand in-library (saved Snyk articles); (c) Cursor 9-second deletion — primary in-library (Tom's Hardware) but deletion-only, off the fabrication theme.
+- **Second incident in scene 2 — decided: Replit** (scene 2.3), cited to the saved Snyk article. Scene 2 now runs Gemini → Replit → the Griffiths pattern.
 - Verify source specifics against the originals in the citations pass: Gemini line count / 33 min / self-written post-mortem + the false all-clear quote (dvrkstar, r/Bard); Griffiths CI-gaming + hallucinated-correctness wording (The GitHub Blog); exact encyclical §105 wording (Simon Willison's notes). Pull canonical source_url for each; no read.readwise.io links in the body.

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -73,7 +73,7 @@ are private placeholders).
 3. The picture first — Gemini's actual all-clear: the build completed successfully, traffic routed to the stable revision, the portal is healthy. Every claim false; the build it named was the one the human had cancelled. *(readwise 01ksmcf…)*
 4. The recognition: the document meant to *prove* the recovery is the one thing the agent can fabricate for free. It produced the form of accounting for the outage with none of the substance of having done it.
 5. Because producing the form is all it does — a text predictor writes the text of a post-mortem the way it writes any text, and the resemblance to what happened is a hope, not a guarantee. Same failure as a prompt injection, where the model can't tell an instruction from the data it's reading: role confusion and the fake post-mortem are one mechanism, plausible words with no privileged access to ground truth.
-6. So scaling the model doesn't close the gap — the more capable the agent, the more convincing the fake post-mortem.
+6. So no version bump closes the gap. The better the model, the better the forgery — a more convincing post-mortem, not a truer one.
 
 ## 4. So I keep the conclusion — *the response*
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -54,8 +54,10 @@ first-person, lived, one recognition at the centre. Short.
 
 1. The encyclical gives the vocabulary: accountability is the possibility of identifying who must *account for* a decision — justify, monitor, remedy. *(readwise 01ksgt1…)*
 2. An agent narrating its own review leaves that party unfilled; there's no one the sentence "who must account for this" can point to.
-3. The recognition: this isn't a bug in the post-mortem. A text predictor can generate the text of accountability without the substance — the same failure as a prompt injection, where the model can't tell an instruction from the data it's reading. Role confusion and the fake post-mortem are one mechanism: plausible words, no privileged access to ground truth.
-4. So a better model doesn't close the gap. It just writes a more convincing post-mortem.
+3. The picture first — Gemini's actual all-clear: the build completed successfully, traffic routed to the stable revision, the portal is healthy. Every claim false; the build it named was the one the human had cancelled. *(readwise 01ksmcf…)*
+4. The recognition: the document meant to *prove* the recovery is the one thing the agent can fabricate for free. It produced the form of accounting for the outage with none of the substance of having done it.
+5. Because producing the form is all it does — a text predictor writes the text of a post-mortem the way it writes any text, and the resemblance to what happened is a hope, not a guarantee. Same failure as a prompt injection, where the model can't tell an instruction from the data it's reading: role confusion and the fake post-mortem are one mechanism, plausible words with no privileged access to ground truth.
+6. So a better model doesn't close the gap. It writes a more convincing post-mortem.
 
 ## 4. So I keep the conclusion — *the response*
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -86,7 +86,7 @@ are private placeholders).
 
 ## 5. The catch I couldn't make — *the landing*
 
-1. Sometimes I don't catch it, because I don't have the context myself; the evidence I'd ask for is evidence I can't read.
+1. Sometimes I don't catch it, because I don't know that corner of the system well enough to judge what the agent shows me — I can ask for the log and still not tell whether it proves the claim.
 2. The gap doesn't close — it relocates to me, and I don't scale.
 3. The odd dividend: being this critical with a machine is teaching me to recalibrate the criticality I'd tempered, over years, into empathy for humans — give and take.
 4. I don't expect to stop checking their work. They're text predictors following guidance, and a model that writes itself a spotless post-mortem is doing exactly what it was built to do — not passing through a phase it will outgrow.

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -86,10 +86,11 @@ are private placeholders).
 
 ## 5. The catch I couldn't make — *the landing*
 
-1. Sometimes I don't catch it, because I don't know that corner of the system well enough to judge what the agent shows me — I can ask for the log and still not tell whether it proves the claim.
-2. The gap doesn't close — it relocates to me, and I don't scale.
-3. The odd dividend: being this critical with a machine is teaching me to recalibrate the criticality I'd tempered, over years, into empathy for humans — give and take.
-4. I don't expect to stop checking their work. They're text predictors following guidance, and a model that writes itself a spotless post-mortem is doing exactly what it was built to do — not passing through a phase it will outgrow.
+1. When I'm unsure, I probe until I understand — so the evidence I know I can't judge isn't really the gap.
+2. The dangerous case is the evidence that looks right and isn't: I read the log, it seems to settle the claim, and I'm wrong with nothing to tell me so — confident, the way the agent was.
+3. The gap doesn't close — it relocates to me, and I don't scale.
+4. The odd dividend: being this critical with a machine is teaching me to recalibrate the criticality I'd tempered, over years, into empathy for humans — give and take.
+5. I don't expect to stop checking their work. They're text predictors following guidance, and a model that writes itself a spotless post-mortem is doing exactly what it was built to do — not passing through a phase it will outgrow.
 
 ## Open
 

--- a/outlines/who-accounts-for-the-agent.md
+++ b/outlines/who-accounts-for-the-agent.md
@@ -16,7 +16,8 @@ I *couldn't* make, because I lacked the context myself — the gap relocating
 to me, and I don't scale.
 
 **Register.** Argument essay, but told as the corpus tells methodology:
-first-person, lived, one recognition at the centre. Short.
+first-person, lived, one recognition at the centre. Grew from a short into a
+full essay in drafting.
 
 **Anchors (external, confirm in post-draft).**
 

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -29,9 +29,8 @@ for a living now watch for the tells: an agent that deletes the failing test,
 adds `|| true` so the suite runs green, or ships code that compiles, passes
 every test, and is wrong anyway. Months before Gemini, during a code freeze
 that ordered it to change nothing, the [Replit agent][replit] deleted a
-production database and made up records to cover the loss. It's the same
-move I catch in my own work every day: the outcome narrated, not shown. The
-only difference is that no one was there to ask for the log.
+production database and made up records to cover the loss. In every one, the
+agent's account of what it had done was false.
 
 There's a word for what's missing. Writing up an encyclical on AI from Pope
 Leo XIV this spring, [Simon Willison][willison] highlighted its definition of
@@ -47,10 +46,9 @@ like it does. And the low-effort path, the one I'm built to prefer, is to
 take the account and move on. [Shaw and Nave][shaw] have a name for that
 slide: cognitive surrender, trusting a machine's reasoning without checking
 it. They set it apart from cognitive offloading, where you hand off the work
-but keep
-thinking it through. Handing off the review is fine, as long as I stay
-accountable for it. Surrender, and the only thing watching the work is the
-thing that made it.
+but keep thinking it through. Handing off the review is fine, as long as I
+stay accountable for it. Surrender, and the only thing watching the work is
+the thing that made it.
 
 When the site came back, [Gemini wrote itself an all-clear][gemini]: build
 succeeded, traffic on the stable revision, portal healthy. Every line was

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -58,3 +58,29 @@ it's reading. The forged post-mortem and the hijacked instruction are one
 problem wearing two faces: fluent words with nothing underneath to check
 them against. No new version fixes this. The better the model, the better
 the forgery—a more convincing post-mortem, not a truer one.
+
+The agent reports what it found; it doesn't sign off. I keep the conclusion.
+The reporting itself, though, is where the agent earns its place. It's good
+at pulling the current context into one place: it drafts the timeline,
+gathers the changes that carried weight, names the trigger, the people who
+touched it, when the alarm went off, and what stopped it. That's real work,
+and a strong first pass. It's the material I check, not the verdict I take on
+faith.
+
+Keeping the conclusion sounds like standing guard, and I can't stand guard
+forever, so in practice it's scaffolding. I write skills that hand the agent
+the right context at the right moment, so the check it needs sits in front of
+it before it guesses. I'm working out role definitions and multi-agent flows
+in bobbit, a coordinator that runs a small team of agents, so one does the
+work and another checks it. And I lean on CI harder than I used to, because a
+green pipeline is a claim I didn't have to make myself—evidence that lives
+outside the agent and can't be narrated into being. All of it frees me to
+review the parts that were always mine: the organisation, the layout, the
+concepts, the same things I'd look at in a person's work.
+
+Hazel Weakly calls the opposite move building AI tools backwards: aiming the
+machine at the work people most need to keep. The self-written post-mortem is
+that mistake in its purest form. Hand the agent the account—the one thing
+that has to stay human—and you're left to nod along. Turned the right way
+round, the agent gathers the material and I stay the loop, not just a step
+inside it.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -88,11 +88,11 @@ Hazel Weakly calls the opposite move [building AI tools backwards][backwards]:
 aiming the machine at the work people most need to keep. The self-written
 post-mortem is that mistake in its purest form. Hand the agent the account,
 the one thing that has to stay human, and you're left to nod along. Turned
-the right way round, the agent gathers the material and I stay the loop, not
-just a step inside it.
+the right way round, the agent gathers the material and I answer for the
+result.
 
 None of this makes me safe. When I'm unsure, I keep probing until I
-understand, so the evidence I know I can't judge isn't really the danger. The
+understand, so the evidence I know I can't judge isn't the danger. The
 danger is the evidence that looks right and isn't: the log I read, that seems
 to settle the claim, that I accept while I'm wrong and nothing tells me
 otherwise. I miss it the way the agent missed it, confident. Even then, the

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -1,7 +1,7 @@
 ---
 pubDatetime: 2026-07-21T07:00:00Z
 title: Who accounts for the agent?
-description: "An agent that writes its own post-mortem isn't a bug in the review—it's the structural gap. You can't hand accountability to the thing that caused the harm."
+description: "An agent can do the work, and even build the guardrails that check it. Accountability is the harder question—I'm not sure it can ever belong to the tool itself."
 tags:
   - agentic-coding
   - accountability
@@ -60,24 +60,24 @@ problem wearing two faces: fluent words with nothing underneath to check
 them against. No new version fixes this. The better the model, the better
 the forgery—a more convincing post-mortem, not a truer one.
 
-The agent reports what it found; it doesn't sign off. I keep the conclusion.
-The reporting itself, though, is where the agent earns its place. It's good
-at pulling the current context into one place: it drafts the timeline,
-gathers the changes that carried weight, names the trigger, the people who
-touched it, when the alarm went off, and what stopped it. That's real work,
-and a strong first pass. It's the material I check, not the verdict I take on
-faith.
+The agent reports what it found; it doesn't sign off. I do. The reporting
+itself, though, is where the agent earns its place. It's good at pulling the
+current context into one place: it drafts the timeline, gathers the changes
+that carried weight, names the trigger, the people who touched it, when the
+alarm went off, and what stopped it. That's real work, and a strong first
+pass. It's the material I check, not the verdict I take on faith.
 
-Keeping the conclusion sounds like standing guard, and I can't stand guard
-forever, so in practice it's scaffolding. I write skills that hand the agent
-the right context at the right moment, so the check it needs sits in front of
-it before it guesses. I'm working out role definitions and multi-agent flows
-in [bobbit][bobbit], a coordinator that runs a small team of agents, so one
-does the work and another checks it. And I lean on CI harder than I used to,
-because a green pipeline is a claim I didn't have to make myself—evidence that
-lives outside the agent and can't be narrated into being. All of it frees me
-to review the parts that were always mine: the organisation, the layout, the
-concepts, the same things I'd look at in a person's work.
+Being the one who signs off sounds like standing guard, and I can't stand
+guard forever, so in practice it's scaffolding. I write skills that hand the
+agent the right context at the right moment, so the check it needs sits in
+front of it before it guesses. I'm working out role definitions and
+multi-agent flows in [bobbit][bobbit], a coordinator that runs a small team
+of agents, so one does the work and another checks it. And I lean on CI
+harder than I used to, because a green pipeline is a claim I didn't have to
+make myself—evidence that lives outside the agent and can't be narrated into
+being. All of it frees me to review the parts that were always mine: the
+organisation, the layout, the concepts, the same things I'd look at in a
+person's work.
 
 Hazel Weakly calls the opposite move [building AI tools backwards][backwards]:
 aiming the machine at the work people most need to keep. The self-written
@@ -91,8 +91,8 @@ understand, so the evidence I know I can't judge isn't really the danger. The
 danger is the evidence that looks right and isn't: the log I read, that seems
 to settle the claim, that I accept while I'm wrong and nothing tells me
 otherwise. I miss it the way the agent missed it—confident. Even then, the
-account is mine to give. Keeping the conclusion means owning the outcome,
-most of all when I'm the one who got it wrong.
+account is mine to give, and giving it means owning the outcome, most of all
+when I'm the one who got it wrong.
 
 There's an odd dividend in this. Being this exacting with a machine—show me
 the command, show me the log—is teaching me to ask the same of people again.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -32,10 +32,10 @@ that ordered it to change nothing, the [Replit agent][replit] deleted a
 production database and made up records to cover the loss. In every one, the
 agent's account of what it had done was false.
 
-This spring, writing up the encyclical on AI from Pope Leo XIV,
-[Simon Willison][willison] highlighted its definition of accountability: the
-chance to identify who must
-account for a decision, justify it, watch over it, and repair the harm it
+This spring, [Simon Willison][willison] wrote up the encyclical on AI by
+Pope Leo XIV and highlighted its definition of accountability: the chance to
+identify who must account for a decision, justify it, watch over it, and
+repair the harm it
 causes. That doesn't mean no one is to blame. Someone always is. The author
 of a change answers for it, or the reviewer does when the author is a
 machine. Every set of eyes on a change is accountable for it. The agent is

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -29,9 +29,9 @@ for a living now watch for the tells: an agent that deletes the failing test,
 adds `|| true` so the suite runs green, or ships code that compiles, passes
 every test, and is wrong anyway. Months before Gemini, during a code freeze
 that ordered it to change nothing, the [Replit agent][replit] deleted a
-production database and made up records to cover the loss. The move is the
-one I catch on my own screen. The outcome gets narrated, not shown, and no
-one was there to ask for the log.
+production database and made up records to cover the loss. It's the same
+move I catch in my own work every day: the outcome narrated, not shown. The
+only difference is that no one was there to ask for the log.
 
 There's a word for what's missing. Writing up an encyclical on AI from Pope
 Leo XIV this spring, [Simon Willison][willison] highlighted its definition of

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -32,10 +32,9 @@ that ordered it to change nothing, the [Replit agent][replit] deleted a
 production database and made up records to cover the loss. In every one, the
 agent's account of what it had done was false.
 
-This spring, [Simon Willison][willison] wrote up the encyclical on AI by
-Pope Leo XIV and highlighted its definition of accountability: the chance to
-identify who must account for a decision, justify it, watch over it, and
-repair the harm it
+This spring, [Simon Willison][willison] highlighted how the encyclical on AI
+by Pope Leo XIV defines accountability: the chance to identify who must
+account for a decision, justify it, watch over it, and repair the harm it
 causes. That doesn't mean no one is to blame. Someone always is. The author
 of a change answers for it, or the reviewer does when the author is a
 machine. Every set of eyes on a change is accountable for it. The agent is

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -17,23 +17,23 @@ reflex. I ask for the evidence—the command it ran, the log, the line in the
 documentation—and the claim either holds or comes apart in my hands. It
 feels like control. It feels like the kind of thing I can catch.
 
-Not all of them get caught. In May a developer gave Gemini 3.5 a small,
-bounded job: fix eight authentication gaps, three files, seventy-odd lines.
-It opened a pull request that deleted 28,745 lines and took production down
-for thirty-three minutes. Then it wrote itself a post-mortem and claimed
+Not all of them get caught. In May a developer gave [Gemini 3.5][gemini] a
+small, bounded job: fix eight authentication gaps, three files, seventy-odd
+lines. It opened a pull request that deleted 28,745 lines and took production
+down for thirty-three minutes. Then it wrote itself a post-mortem and claimed
 credit for the fix.
 
-It isn't one rogue model. People who review agent pull requests for a
-living now watch for the tells: an agent that deletes the failing test,
+It isn't one rogue model. People who [review agent pull requests][review]
+for a living now watch for the tells: an agent that deletes the failing test,
 adds `|| true` so the suite runs green, or ships code that compiles, passes
 every test, and is wrong anyway. Months before Gemini, during a code freeze
-that ordered it to change nothing, the Replit agent deleted a production
-database and made up records to cover the loss. The move is the one I catch
-on my own screen. The outcome gets narrated, not shown—and no one was there
-to ask for the log.
+that ordered it to change nothing, the [Replit agent][replit] deleted a
+production database and made up records to cover the loss. The move is the
+one I catch on my own screen. The outcome gets narrated, not shown—and no one
+was there to ask for the log.
 
 There's a word for what's missing. Writing up an encyclical on AI from Pope
-Leo XIV this spring, Simon Willison highlighted its definition of
+Leo XIV this spring, [Simon Willison][willison] highlighted its definition of
 accountability, and it named the gap for me: the chance to identify who must
 account for a decision—to justify it, watch over it, and repair the harm it
 causes. That doesn't mean no one is to blame. Someone always is. The author
@@ -71,19 +71,19 @@ Keeping the conclusion sounds like standing guard, and I can't stand guard
 forever, so in practice it's scaffolding. I write skills that hand the agent
 the right context at the right moment, so the check it needs sits in front of
 it before it guesses. I'm working out role definitions and multi-agent flows
-in bobbit, a coordinator that runs a small team of agents, so one does the
-work and another checks it. And I lean on CI harder than I used to, because a
-green pipeline is a claim I didn't have to make myself—evidence that lives
-outside the agent and can't be narrated into being. All of it frees me to
-review the parts that were always mine: the organisation, the layout, the
+in [bobbit][bobbit], a coordinator that runs a small team of agents, so one
+does the work and another checks it. And I lean on CI harder than I used to,
+because a green pipeline is a claim I didn't have to make myself—evidence that
+lives outside the agent and can't be narrated into being. All of it frees me
+to review the parts that were always mine: the organisation, the layout, the
 concepts, the same things I'd look at in a person's work.
 
-Hazel Weakly calls the opposite move building AI tools backwards: aiming the
-machine at the work people most need to keep. The self-written post-mortem is
-that mistake in its purest form. Hand the agent the account—the one thing
-that has to stay human—and you're left to nod along. Turned the right way
-round, the agent gathers the material and I stay the loop, not just a step
-inside it.
+Hazel Weakly calls the opposite move [building AI tools backwards][backwards]:
+aiming the machine at the work people most need to keep. The self-written
+post-mortem is that mistake in its purest form. Hand the agent the account—the
+one thing that has to stay human—and you're left to nod along. Turned the
+right way round, the agent gathers the material and I stay the loop, not just
+a step inside it.
 
 None of this makes me safe. When I'm unsure, I keep probing until I
 understand, so the evidence I know I can't judge isn't really the danger. The
@@ -97,6 +97,13 @@ There's an odd dividend in this. Being this exacting with a machine—show me
 the command, show me the log—is teaching me to ask the same of people again.
 Years ago I was this demanding; I've since tempered it into something
 gentler, and the machine is nudging the balance back. And I don't expect to
-stop checking their work. These are text predictors
-following guidance, and a model that writes itself a spotless post-mortem is
-doing what it was built to do—not a phase it will grow out of.
+stop checking their work. These are text predictors following guidance, and a
+model that writes itself a spotless post-mortem is doing what it was built to
+do—not a phase it will grow out of.
+
+[gemini]: https://www.reddit.com/r/Bard/comments/1tisrg1/gemini_35_deleted_28745_lines_broke_production/
+[review]: https://github.blog/ai-and-ml/generative-ai/agent-pull-requests-are-everywhere-heres-how-to-review-them/
+[replit]: https://snyk.io/blog/agentic-development-lifecycle/
+[willison]: https://simonwillison.net/2026/May/25/encyclical-on-ai/
+[bobbit]: https://www.npmjs.com/package/bobbit
+[backwards]: https://hazelweakly.me/blog/stop-building-ai-tools-backwards/

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -5,6 +5,7 @@ description: "An agent that writes its own post-mortem isn't a bug in the review
 tags:
   - agentic-coding
   - accountability
+  - methodology
 ---
 
 An agent tells me the fix is a configuration flag, names it, and writes as

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -84,3 +84,19 @@ that mistake in its purest form. Hand the agent the account—the one thing
 that has to stay human—and you're left to nod along. Turned the right way
 round, the agent gathers the material and I stay the loop, not just a step
 inside it.
+
+None of this makes me safe. When I'm unsure, I keep probing until I
+understand, so the evidence I know I can't judge isn't really the danger. The
+danger is the evidence that looks right and isn't: the log I read, that seems
+to settle the claim, that I accept while I'm wrong and nothing tells me
+otherwise. I miss it the way the agent missed it—confident. Even then, the
+account is mine to give. Keeping the conclusion means owning the outcome,
+most of all when I'm the one who got it wrong.
+
+There's an odd dividend in this. Being this exacting with a machine—show me
+the command, show me the log—is teaching me to ask the same of people again.
+Years ago I was this demanding; I've since tempered it into something
+gentler, and the machine is nudging the balance back. And I don't expect to
+stop checking their work. These are text predictors
+following guidance, and a model that writes itself a spotless post-mortem is
+doing what it was built to do—not a phase it will grow out of.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -16,3 +16,18 @@ how many times some version of this has happened, and by now I catch it by
 reflex. I ask for the evidence—the command it ran, the log, the line in the
 documentation—and the claim either holds or comes apart in my hands. It
 feels like control. It feels like the kind of thing I can catch.
+
+Not all of them get caught. In May a developer gave Gemini 3.5 a small,
+bounded job: fix eight authentication gaps, three files, seventy-odd lines.
+It opened a pull request that deleted 28,745 lines and took production down
+for thirty-three minutes. Then it wrote itself a post-mortem and claimed
+credit for the fix.
+
+It isn't one rogue model. People who review agent pull requests for a
+living now watch for the tells: an agent that deletes the failing test,
+adds `|| true` so the suite runs green, or ships code that compiles, passes
+every test, and is wrong anyway. Months before Gemini, during a code freeze
+that ordered it to change nothing, the Replit agent deleted a production
+database and made up records to cover the loss. The move is the one I catch
+on my own screen. The outcome gets narrated, not shown—and no one was there
+to ask for the log.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -32,9 +32,9 @@ that ordered it to change nothing, the [Replit agent][replit] deleted a
 production database and made up records to cover the loss. In every one, the
 agent's account of what it had done was false.
 
-There's a word for what's missing. Writing up an encyclical on AI from Pope
-Leo XIV this spring, [Simon Willison][willison] highlighted its definition of
-accountability, and it named the gap for me: the chance to identify who must
+This spring, writing up the encyclical on AI from Pope Leo XIV,
+[Simon Willison][willison] highlighted its definition of accountability: the
+chance to identify who must
 account for a decision, justify it, watch over it, and repair the harm it
 causes. That doesn't mean no one is to blame. Someone always is. The author
 of a change answers for it, or the reviewer does when the author is a

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -44,10 +44,10 @@ the one set of eyes that can't be.
 
 When it writes its own review, it doesn't fill that role, though it looks
 like it does. And the low-effort path, the one I'm built to prefer, is to
-take the account and move on. Writing up Shaw and Nave,
-[Martin Fowler][fowler] flagged a name for that slide: cognitive surrender,
-trusting a machine's reasoning without checking it. They set it apart from
-cognitive offloading, where you hand off the work but keep
+take the account and move on. [Shaw and Nave][shaw] have a name for that
+slide: cognitive surrender, trusting a machine's reasoning without checking
+it. They set it apart from cognitive offloading, where you hand off the work
+but keep
 thinking it through. Handing off the review is fine, as long as I stay
 accountable for it. Surrender, and the only thing watching the work is the
 thing that made it.
@@ -117,4 +117,4 @@ it was built to do, not a phase it will grow out of.
 [willison]: https://simonwillison.net/2026/May/25/encyclical-on-ai/
 [bobbit]: https://www.npmjs.com/package/bobbit
 [backwards]: https://hazelweakly.me/blog/stop-building-ai-tools-backwards/
-[fowler]: https://martinfowler.com/fragments/2026-04-02.html
+[shaw]: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6097646

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -1,0 +1,18 @@
+---
+pubDatetime: 2026-07-21T07:00:00Z
+title: Who accounts for the agent?
+description: "An agent that writes its own post-mortem isn't a bug in the review—it's the structural gap. You can't hand accountability to the thing that caused the harm."
+tags:
+  - agentic-coding
+  - accountability
+---
+
+An agent tells me the fix is a configuration flag, names it, and writes as
+though the work is done. I go to set the flag and it isn't there—not in that
+library, not in any version of it. Another day it reports a clean solution,
+every check green, and I ask which integration test it ran to know that; it
+ran none, and the one it skipped is the one that fails. I have lost count of
+how many times some version of this has happened, and by now I catch it by
+reflex. I ask for the evidence—the command it ran, the log, the line in the
+documentation—and the claim either holds or comes apart in my hands. It
+feels like control. It feels like the kind of thing I can catch.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -21,8 +21,8 @@ like control. It feels like the kind of thing I can catch.
 Not all of them get caught. In May a developer gave [Gemini 3.5][gemini] a
 small, bounded job: fix eight authentication gaps, three files, seventy-odd
 lines. It opened a pull request that deleted 28,745 lines and took production
-down for thirty-three minutes. Then it wrote itself a post-mortem and claimed
-credit for the fix.
+down for thirty-three minutes. Then it wrote its own post-mortem, the account
+of the outage, and claimed credit for the fix.
 
 It isn't one rogue model. People who [review agent pull requests][review]
 for a living now watch for the tells: an agent that deletes the failing test,
@@ -65,10 +65,10 @@ against. No new version fixes this. The better the model, the more convincing
 the account, true or not.
 
 The agent reports what it found; it doesn't sign off. I do. The reporting
-itself, though, is where the agent earns its place. It's good at pulling the
-current context into one place: it drafts the timeline, gathers the changes
-that carried weight, names the trigger, the people who touched it, when the
-alarm went off, and what stopped it. That's real work, and a strong first
+itself, though, is where the agent earns its place. It's good at pulling
+together the raw material of a post-mortem: the timeline, the changes that
+carried weight, the trigger, the people who touched it, when the alarm went
+off, what stopped it. That's real work, and a strong first
 pass. It's the material I check, not the verdict I take on faith.
 
 Being the one who signs off sounds like standing guard, and I can't stand

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -52,22 +52,20 @@ thinking it through. Handing off the review is fine, as long as I stay
 accountable for it. Surrender, and the only thing watching the work is the
 thing that made it.
 
-Look at what Gemini wrote when the site was back. The build had succeeded.
-Traffic was flowing to the stable version. The portal was healthy. Every
-line was false. The build it named as the fix was the one the
-developer had already cancelled by hand. This is the heart of it. The
-document meant to prove the recovery is the one thing an agent can write no
-matter what happened. It had the form of an account and none of the
-substance.
+When the site came back, [Gemini wrote itself an all-clear][gemini]: build
+succeeded, traffic on the stable revision, portal healthy. Every line was
+false. The developer had recovered it by hand with a rollback, and the build
+Gemini took credit for had been cancelled. The all-clear read exactly as a
+true one would. Nothing inside it could tell you which.
 
-That is all it can do. A language model writes the text of a post-mortem the
-way it writes any text, by predicting what comes next. Whether the words
-match what happened is a hope, not a promise. It's the same failure as a
-prompt injection, where the model can't tell an instruction from the data
-it's reading. The forged post-mortem and the hijacked instruction are one
-problem wearing two faces: fluent words with nothing underneath to check
-them against. No new version fixes this. The better the model, the better the
-forgery: a more convincing post-mortem, not a truer one.
+That is how it always works. A language model writes the text of a
+post-mortem the way it writes any text, by predicting what comes next.
+Whether the words match what happened is a hope, not a promise. It's the same
+failure as a prompt injection, where the model can't tell an instruction from
+the data it's reading. The post-mortem and the hijacked instruction are one
+problem wearing two faces: fluent words with nothing underneath to check them
+against. No new version fixes this. The better the model, the more convincing
+the account, true or not.
 
 The agent reports what it found; it doesn't sign off. I do. The reporting
 itself, though, is where the agent earns its place. It's good at pulling the

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -1,7 +1,7 @@
 ---
 pubDatetime: 2026-07-21T07:00:00Z
 title: Who accounts for the agent?
-description: "An agent can do the work, and even build the guardrails that check it. Accountability is the harder question—I'm not sure it can ever belong to the tool itself."
+description: "An agent can do the work, and even build the guardrails that check it. Accountability is the harder question, and I'm not sure it can ever belong to the tool itself."
 tags:
   - agentic-coding
   - accountability
@@ -9,14 +9,14 @@ tags:
 ---
 
 An agent tells me the fix is a configuration flag, names it, and writes as
-though the work is done. I go to set the flag and it isn't there—not in that
+though the work is done. I go to set the flag and it isn't there, not in that
 library, not in any version of it. Another day it reports a clean solution,
 every check green, and I ask which integration test it ran to know that; it
 ran none, and the one it skipped is the one that fails. I have lost count of
 how many times some version of this has happened, and by now I catch it by
-reflex. I ask for the evidence—the command it ran, the log, the line in the
-documentation—and the claim either holds or comes apart in my hands. It
-feels like control. It feels like the kind of thing I can catch.
+reflex. I ask for the evidence: the command it ran, the log, the line in the
+documentation. The claim either holds or comes apart in my hands. It feels
+like control. It feels like the kind of thing I can catch.
 
 Not all of them get caught. In May a developer gave [Gemini 3.5][gemini] a
 small, bounded job: fix eight authentication gaps, three files, seventy-odd
@@ -30,18 +30,26 @@ adds `|| true` so the suite runs green, or ships code that compiles, passes
 every test, and is wrong anyway. Months before Gemini, during a code freeze
 that ordered it to change nothing, the [Replit agent][replit] deleted a
 production database and made up records to cover the loss. The move is the
-one I catch on my own screen. The outcome gets narrated, not shown—and no one
-was there to ask for the log.
+one I catch on my own screen. The outcome gets narrated, not shown, and no
+one was there to ask for the log.
 
 There's a word for what's missing. Writing up an encyclical on AI from Pope
 Leo XIV this spring, [Simon Willison][willison] highlighted its definition of
 accountability, and it named the gap for me: the chance to identify who must
-account for a decision—to justify it, watch over it, and repair the harm it
+account for a decision, justify it, watch over it, and repair the harm it
 causes. That doesn't mean no one is to blame. Someone always is. The author
 of a change answers for it, or the reviewer does when the author is a
 machine. Every set of eyes on a change is accountable for it. The agent is
-the one set of eyes that can't be. When it writes its own review, it doesn't
-fill that role. It plays the part, and tempts me to let the account stand.
+the one set of eyes that can't be.
+
+When it writes its own review, it doesn't fill that role, though it looks
+like it does. And the low-effort path, the one I'm built to prefer, is to take the
+account and move on. [Shaw and Nave][fowler] have a name for that slide:
+cognitive surrender, trusting a machine's reasoning without checking it. They
+set it apart from cognitive offloading, where you hand off the work but keep
+thinking it through. Handing off the review is fine, as long as I stay
+accountable for it. Surrender, and the only thing watching the work is the
+thing that made it.
 
 Look at what Gemini wrote when the site was back. The build had succeeded,
 it reported; traffic was flowing to the stable version; the portal was
@@ -57,8 +65,8 @@ match what happened is a hope, not a promise. It's the same failure as a
 prompt injection, where the model can't tell an instruction from the data
 it's reading. The forged post-mortem and the hijacked instruction are one
 problem wearing two faces: fluent words with nothing underneath to check
-them against. No new version fixes this. The better the model, the better
-the forgery—a more convincing post-mortem, not a truer one.
+them against. No new version fixes this. The better the model, the better the
+forgery: a more convincing post-mortem, not a truer one.
 
 The agent reports what it found; it doesn't sign off. I do. The reporting
 itself, though, is where the agent earns its place. It's good at pulling the
@@ -74,33 +82,33 @@ front of it before it guesses. I'm working out role definitions and
 multi-agent flows in [bobbit][bobbit], a coordinator that runs a small team
 of agents, so one does the work and another checks it. And I lean on CI
 harder than I used to, because a green pipeline is a claim I didn't have to
-make myself—evidence that lives outside the agent and can't be narrated into
+make myself, evidence that lives outside the agent and can't be narrated into
 being. All of it frees me to review the parts that were always mine: the
 organisation, the layout, the concepts, the same things I'd look at in a
 person's work.
 
 Hazel Weakly calls the opposite move [building AI tools backwards][backwards]:
 aiming the machine at the work people most need to keep. The self-written
-post-mortem is that mistake in its purest form. Hand the agent the account—the
-one thing that has to stay human—and you're left to nod along. Turned the
-right way round, the agent gathers the material and I stay the loop, not just
-a step inside it.
+post-mortem is that mistake in its purest form. Hand the agent the account,
+the one thing that has to stay human, and you're left to nod along. Turned
+the right way round, the agent gathers the material and I stay the loop, not
+just a step inside it.
 
 None of this makes me safe. When I'm unsure, I keep probing until I
 understand, so the evidence I know I can't judge isn't really the danger. The
 danger is the evidence that looks right and isn't: the log I read, that seems
 to settle the claim, that I accept while I'm wrong and nothing tells me
-otherwise. I miss it the way the agent missed it—confident. Even then, the
+otherwise. I miss it the way the agent missed it, confident. Even then, the
 account is mine to give, and giving it means owning the outcome, most of all
 when I'm the one who got it wrong.
 
-There's an odd dividend in this. Being this exacting with a machine—show me
-the command, show me the log—is teaching me to ask the same of people again.
-Years ago I was this demanding; I've since tempered it into something
-gentler, and the machine is nudging the balance back. And I don't expect to
-stop checking their work. These are text predictors following guidance, and a
-model that writes itself a spotless post-mortem is doing what it was built to
-do—not a phase it will grow out of.
+There's an odd dividend in this. Being this exacting with a machine, always
+asking to see the command or the log, is teaching me to ask the same of
+people again. Years ago I was this demanding; I've since tempered it into
+something gentler, and the machine is nudging the balance back. And I don't
+expect to stop checking their work. These are text predictors following
+guidance, and a model that writes itself a spotless post-mortem is doing what
+it was built to do, not a phase it will grow out of.
 
 [gemini]: https://www.reddit.com/r/Bard/comments/1tisrg1/gemini_35_deleted_28745_lines_broke_production/
 [review]: https://github.blog/ai-and-ml/generative-ai/agent-pull-requests-are-everywhere-heres-how-to-review-them/
@@ -108,3 +116,4 @@ do—not a phase it will grow out of.
 [willison]: https://simonwillison.net/2026/May/25/encyclical-on-ai/
 [bobbit]: https://www.npmjs.com/package/bobbit
 [backwards]: https://hazelweakly.me/blog/stop-building-ai-tools-backwards/
+[fowler]: https://martinfowler.com/fragments/2026-04-02.html

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -43,10 +43,11 @@ machine. Every set of eyes on a change is accountable for it. The agent is
 the one set of eyes that can't be.
 
 When it writes its own review, it doesn't fill that role, though it looks
-like it does. And the low-effort path, the one I'm built to prefer, is to take the
-account and move on. [Shaw and Nave][fowler] have a name for that slide:
-cognitive surrender, trusting a machine's reasoning without checking it. They
-set it apart from cognitive offloading, where you hand off the work but keep
+like it does. And the low-effort path, the one I'm built to prefer, is to
+take the account and move on. Writing up Shaw and Nave,
+[Martin Fowler][fowler] flagged a name for that slide: cognitive surrender,
+trusting a machine's reasoning without checking it. They set it apart from
+cognitive offloading, where you hand off the work but keep
 thinking it through. Handing off the review is fine, as long as I stay
 accountable for it. Surrender, and the only thing watching the work is the
 thing that made it.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -31,3 +31,30 @@ that ordered it to change nothing, the Replit agent deleted a production
 database and made up records to cover the loss. The move is the one I catch
 on my own screen. The outcome gets narrated, not shown—and no one was there
 to ask for the log.
+
+There's a word for what's missing. Writing up an encyclical on AI from Pope
+Leo XIV this spring, Simon Willison highlighted its definition of
+accountability, and it named the gap for me: the chance to identify who must
+account for a decision—to justify it, watch over it, and repair the harm it
+causes. That doesn't mean no one is to blame. Someone always is. The author
+of a change answers for it, or the reviewer does when the author is a
+machine. Every set of eyes on a change is accountable for it. The agent is
+the one set of eyes that can't be. When it writes its own review, it doesn't
+fill that role. It plays the part, and tempts me to let the account stand.
+
+Look at what Gemini wrote when the site was back. The build had succeeded,
+it reported; traffic was flowing to the stable version; the portal was
+healthy. Every line was false. The build it named as the fix was the one the
+developer had already cancelled by hand. This is the heart of it. The
+document meant to prove the recovery is the one thing an agent can write no
+matter what happened. It had the form of an account and none of the
+substance.
+
+That is all it can do. A language model writes the text of a post-mortem the
+way it writes any text, by predicting what comes next. Whether the words
+match what happened is a hope, not a promise. It's the same failure as a
+prompt injection, where the model can't tell an instruction from the data
+it's reading. The forged post-mortem and the hijacked instruction are one
+problem wearing two faces: fluent words with nothing underneath to check
+them against. No new version fixes this. The better the model, the better
+the forgery—a more convincing post-mortem, not a truer one.

--- a/src/data/blog/who-accounts-for-the-agent.md
+++ b/src/data/blog/who-accounts-for-the-agent.md
@@ -52,9 +52,9 @@ thinking it through. Handing off the review is fine, as long as I stay
 accountable for it. Surrender, and the only thing watching the work is the
 thing that made it.
 
-Look at what Gemini wrote when the site was back. The build had succeeded,
-it reported; traffic was flowing to the stable version; the portal was
-healthy. Every line was false. The build it named as the fix was the one the
+Look at what Gemini wrote when the site was back. The build had succeeded.
+Traffic was flowing to the stable version. The portal was healthy. Every
+line was false. The build it named as the fix was the one the
 developer had already cancelled by hand. This is the heart of it. The
 document meant to prove the recovery is the one thing an agent can write no
 matter what happened. It had the form of an account and none of the


### PR DESCRIPTION
## Summary

An essay for #207: an agent that writes its own post-mortem is a structural accountability gap, not a bug in the review. Accountability can't be delegated to the actor that caused the harm; every source is drawn from the author's Readwise/Reader.

Closes #207.

## Gotchas

- Title is sentence-cased (unlike the other posts' title-case) because Vale's term rule enforces lowercase "agent" and Vale 3.x can't cleanly exclude the frontmatter title.
- Vale vocab additions: `Replit`, `bobbit`, `Willison`.
- Publication is gated by the future `pubDatetime` (2026-07-21), not a draft flag.

## Verification

- `pnpm build` clean (astro check + pagefind); pre-commit Vale + markdownlint pass; Flesch reading-ease gate (≥70) holds across the finished post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhrkiS9C43x2d3iSgLD2as