### PR TITLE
Paginate webmention fetch so no mentions are dropped

### DIFF
--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -44,9 +44,15 @@ const PER_PAGE = 100;
 export async function getWebmentions(target: string): Promise<Webmentions> {
   if (!PUBLIC_WEBMENTION_IO_USERNAME) return empty;
 
+  // Keyset pagination on wm-id (sort-dir=up, advancing since_id) rather
+  // than page/per-page offsets: a mention added or removed on
+  // webmention.io mid-fetch shifts every later offset, silently dropping
+  // or duplicating a boundary entry. since_id tracks by ID, so surviving
+  // entries never shift and strictly-greater guarantees no duplicates.
   const children: WebmentionEntry[] = [];
-  for (let page = 0; ; page++) {
-    const url = `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}&per-page=${PER_PAGE}&page=${page}`;
+  let sinceId = 0;
+  for (;;) {
+    const url = `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}&per-page=${PER_PAGE}&sort-dir=up&since_id=${sinceId}`;
     const res = await fetch(url);
     if (!res.ok) {
       throw new Error(`Webmention fetch ${res.status} for ${target}`);
@@ -57,7 +63,11 @@ export async function getWebmentions(target: string): Promise<Webmentions> {
     children.push(...batch);
 
     if (batch.length < PER_PAGE) break;
+    sinceId = Math.max(...batch.map(c => c["wm-id"]));
   }
+
+  // sort-dir=up yields oldest-first; restore newest-first for display.
+  children.sort((a, b) => b["wm-id"] - a["wm-id"]);
 
   return {
     likes: children.filter(c => c["wm-property"] === "like-of"),

--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -44,16 +44,9 @@ const PER_PAGE = 100;
 export async function getWebmentions(target: string): Promise<Webmentions> {
   if (!PUBLIC_WEBMENTION_IO_USERNAME) return empty;
 
-  // Keyset pagination on wm-id (sort-dir=up, advancing since_id) rather
-  // than page/per-page offsets: a mention added or removed on
-  // webmention.io mid-fetch shifts every later offset, silently dropping
-  // or duplicating a boundary entry. since_id tracks by ID, so surviving
-  // entries never shift and strictly-greater guarantees no duplicates.
-  // Terminate on an empty batch, not a short one: a short page would
-  // assume the server honours our requested per-page, so a server-side
-  // cap below PER_PAGE would silently stop us after the first batch.
-  // per-page only bounds the request count; keep it high to minimise
-  // build-time round-trips on posts with many mentions.
+  // webmention.io's since_id is a forward-only cursor (returns wm-id
+  // strictly greater, with no descending equivalent), so we fetch
+  // oldest-first and advance since_id past each batch.
   const children: WebmentionEntry[] = [];
   let sinceId = 0;
   for (;;) {
@@ -65,13 +58,15 @@ export async function getWebmentions(target: string): Promise<Webmentions> {
 
     const data = (await res.json()) as { children?: WebmentionEntry[] };
     const batch = data.children ?? [];
+    // End of data is an empty batch, not a short one: the server may cap
+    // per-page, so a short page isn't a reliable end signal.
     if (batch.length === 0) break;
 
     children.push(...batch);
     sinceId = Math.max(...batch.map(c => c["wm-id"]));
   }
 
-  // sort-dir=up yields oldest-first; restore newest-first for display.
+  // The cursor forced oldest-first; restore newest-first for display.
   children.sort((a, b) => b["wm-id"] - a["wm-id"]);
 
   return {

--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -49,6 +49,11 @@ export async function getWebmentions(target: string): Promise<Webmentions> {
   // webmention.io mid-fetch shifts every later offset, silently dropping
   // or duplicating a boundary entry. since_id tracks by ID, so surviving
   // entries never shift and strictly-greater guarantees no duplicates.
+  // Terminate on an empty batch, not a short one: a short page would
+  // assume the server honours our requested per-page, so a server-side
+  // cap below PER_PAGE would silently stop us after the first batch.
+  // per-page only bounds the request count; keep it high to minimise
+  // build-time round-trips on posts with many mentions.
   const children: WebmentionEntry[] = [];
   let sinceId = 0;
   for (;;) {
@@ -60,9 +65,9 @@ export async function getWebmentions(target: string): Promise<Webmentions> {
 
     const data = (await res.json()) as { children?: WebmentionEntry[] };
     const batch = data.children ?? [];
-    children.push(...batch);
+    if (batch.length === 0) break;
 
-    if (batch.length < PER_PAGE) break;
+    children.push(...batch);
     sinceId = Math.max(...batch.map(c => c["wm-id"]));
   }
 

--- a/src/utils/getWebmentions.ts
+++ b/src/utils/getWebmentions.ts
@@ -39,17 +39,25 @@ const empty: Webmentions = {
   mentions: [],
 };
 
+const PER_PAGE = 100;
+
 export async function getWebmentions(target: string): Promise<Webmentions> {
   if (!PUBLIC_WEBMENTION_IO_USERNAME) return empty;
 
-  const url = `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}&per-page=100`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Webmention fetch ${res.status} for ${target}`);
-  }
+  const children: WebmentionEntry[] = [];
+  for (let page = 0; ; page++) {
+    const url = `https://webmention.io/api/mentions.jf2?target=${encodeURIComponent(target)}&per-page=${PER_PAGE}&page=${page}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Webmention fetch ${res.status} for ${target}`);
+    }
 
-  const data = (await res.json()) as { children?: WebmentionEntry[] };
-  const children = data.children ?? [];
+    const data = (await res.json()) as { children?: WebmentionEntry[] };
+    const batch = data.children ?? [];
+    children.push(...batch);
+
+    if (batch.length < PER_PAGE) break;
+  }
 
   return {
     likes: children.filter(c => c["wm-property"] === "like-of"),


### PR DESCRIPTION
## Summary

Posts with more than 100 webmentions now render all of them.
`getWebmentions` fetched a single `per-page=100` page and dropped the
rest silently; it now paginates the webmention.io jf2 API until an empty
batch ends the run.

Paging is keyset — it advances `since_id` (with `sort-dir=up`) rather
than `page`/`per-page` offsets, so a mention added or removed on
webmention.io mid-fetch can't shift a page boundary and silently drop or
duplicate an entry. Termination is driven off the cursor and stops on an
empty batch, so correctness doesn't depend on the server honouring the
requested `per-page`.

Closes #217

## Gotchas

- `sort-dir=up` returns oldest-first, so the collected children are
  re-sorted by `wm-id` descending to preserve the component's existing
  newest-first display order.
- `per-page=100` only bounds request count now, not correctness; it's
  kept high to limit build-time round-trips on high-mention posts.

## Verification

- `astro check`, ESLint, and Prettier all clean (CI-covered).

## Follow-up

- #353 tracks bootstrapping Vitest to regression-test the pagination
  loop; deliberately split out to keep this PR scoped to the fix.