### PR TITLE
Add popular-posts widget from Cloudflare analytics

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,11 @@ jobs:
       # rel="webmention" link). Committed here rather than an Actions
       # Variable so the webmention receiver is configured as IaC. See #148.
       PUBLIC_WEBMENTION_IO_USERNAME: blog.alunduil.com
+      # Scoped Cloudflare token (Account Analytics → Read) for the
+      # build-time popular-posts ranking. Secret, unlike the public beacon
+      # from #141. Absent (unset secret) → the widget degrades to nothing.
+      # See #142.
+      CLOUDFLARE_ANALYTICS_API_TOKEN: ${{ secrets.CLOUDFLARE_ANALYTICS_API_TOKEN }}
     concurrency:
       group: ${{ github.workflow }}-build-${{ github.ref }}
       cancel-in-progress: false

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -60,6 +60,15 @@ export default defineConfig({
         context: "client",
         optional: true,
       }),
+      // Scoped Cloudflare token (Account Analytics → Read) used at build time
+      // to rank popular posts. Optional so builds without the secret — local
+      // dev, fork PRs, CI before it is provisioned — degrade to no widget
+      // instead of failing.
+      CLOUDFLARE_ANALYTICS_API_TOKEN: envField.string({
+        access: "secret",
+        context: "server",
+        optional: true,
+      }),
     },
   },
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,4 +25,10 @@ export const SITE = {
   // Leave Cloudflare's automatic injection off: the beacon ships from
   // Layout.astro, so edge injection would double-count every pageview.
   cloudflareWebAnalyticsToken: "3cda180b29054d619e163d6cafee3119",
+  // Cloudflare account that owns the Web Analytics RUM dataset queried at
+  // build time for the popular-posts ranking (see getPopularPosts.ts). The
+  // account tag is an identifier, not a credential — the read scope lives in
+  // the CLOUDFLARE_ANALYTICS_API_TOKEN secret — so it ships as IaC here
+  // alongside the public beacon ID.
+  cloudflareAnalyticsAccountTag: "76626ec3f004e86f1a4d85faca9ac3a2",
 } as const;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Socials from "@/components/Socials.astro";
 import LinkButton from "@/components/LinkButton.astro";
 import Card from "@/components/Card.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
+import { getPopularPosts } from "@/utils/getPopularPosts";
 import IconRss from "@/assets/icons/IconRss.svg";
 import IconArrowRight from "@/assets/icons/IconArrowRight.svg";
 import { SITE } from "@/config";
@@ -17,6 +18,7 @@ const posts = await getCollection("blog");
 const sortedPosts = getSortedPosts(posts);
 const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
 const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
+const popularPosts = await getPopularPosts(posts);
 ---
 
 <Layout>
@@ -79,6 +81,25 @@ const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
           <h2 class="text-2xl font-semibold tracking-wide">Featured</h2>
           <ul>
             {featuredPosts.map(data => (
+              <Card variant="h3" {...data} />
+            ))}
+          </ul>
+        </section>
+      )
+    }
+
+    {
+      popularPosts.length > 0 && (
+        <section
+          id="popular"
+          class:list={[
+            "pt-12 pb-6",
+            { "border-b border-border": recentPosts.length > 0 },
+          ]}
+        >
+          <h2 class="text-2xl font-semibold tracking-wide">Popular</h2>
+          <ul>
+            {popularPosts.map(data => (
               <Card variant="h3" {...data} />
             ))}
           </ul>

--- a/src/utils/getPopularPosts.ts
+++ b/src/utils/getPopularPosts.ts
@@ -1,0 +1,138 @@
+import type { CollectionEntry } from "astro:content";
+import { CLOUDFLARE_ANALYTICS_API_TOKEN } from "astro:env/server";
+import { SITE } from "@/config";
+import { getPath } from "./getPath";
+import postFilter from "./postFilter";
+
+const ANALYTICS_ENDPOINT = "https://api.cloudflare.com/client/v4/graphql";
+
+// Rolling window for "popular": reflects what's resonating now rather than
+// ossifying around a handful of legacy hits.
+const WINDOW_DAYS = 90;
+
+// Distinct paths pulled from the API before joining against the collection.
+// Well above the post count so the join isn't starved by non-post paths
+// (the homepage, feeds, dead pre-migration URLs) ranking above real posts.
+const PATH_LIMIT = 100;
+
+const POPULAR_POST_COUNT = 5;
+
+// Upstream AstroPaper content that ships in the collection (see the "AstroPaper
+// upstream" list in CLAUDE.md). The example drafts and most tutorial posts
+// carry a foreign `author`, but the release notes under `_releases/` set none
+// and so inherit SITE.author — the author filter alone would let them rank.
+// `_hakyll`/`_nikola` are *restored author* posts, so this excludes by exact
+// upstream directory rather than the leading underscore.
+const UPSTREAM_DIRS = ["_releases", "examples"];
+
+function isUpstream(filePath: string | undefined): boolean {
+  return (filePath?.split("/") ?? []).some(seg => UPSTREAM_DIRS.includes(seg));
+}
+
+type RumRow = { count: number; dimensions: { requestPath: string } };
+
+// Cloudflare's RUM counts are adaptively sampled (they arrive rounded to
+// tens), so the value is only meaningful as a ranking key, never a display
+// figure. Trailing-slash variants of the same path are summed.
+function normalizePath(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed === "" ? "/" : trimmed;
+}
+
+async function fetchPathCounts(): Promise<Map<string, number>> {
+  const host = new URL(SITE.website).host;
+  const since = new Date(
+    Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+
+  // Values interpolated below are our own constants (config, computed
+  // window) — no external input, so no injection surface.
+  const query = `query {
+    viewer {
+      accounts(filter: { accountTag: ${JSON.stringify(SITE.cloudflareAnalyticsAccountTag)} }) {
+        rumPageloadEventsAdaptiveGroups(
+          limit: ${PATH_LIMIT}
+          filter: { datetime_geq: ${JSON.stringify(since)}, requestHost: ${JSON.stringify(host)} }
+          orderBy: [count_DESC]
+        ) {
+          count
+          dimensions { requestPath }
+        }
+      }
+    }
+  }`;
+
+  const res = await fetch(ANALYTICS_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${CLOUDFLARE_ANALYTICS_API_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) {
+    throw new Error(`Analytics fetch ${res.status}`);
+  }
+
+  const json = (await res.json()) as {
+    data?: {
+      viewer?: { accounts?: { rumPageloadEventsAdaptiveGroups: RumRow[] }[] };
+    };
+    errors?: unknown;
+  };
+  if (json.errors) {
+    throw new Error(`Analytics query error: ${JSON.stringify(json.errors)}`);
+  }
+
+  const rows =
+    json.data?.viewer?.accounts?.[0]?.rumPageloadEventsAdaptiveGroups ?? [];
+
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const key = normalizePath(row.dimensions.requestPath);
+    counts.set(key, (counts.get(key) ?? 0) + row.count);
+  }
+  return counts;
+}
+
+/**
+ * Rank the author's own posts by page views over a rolling window, sourced
+ * from Cloudflare's RUM analytics at build time.
+ *
+ * Eligibility is the author's own writing only: posts authored by
+ * {@link SITE.author} (foreign-authored guest tutorials drop out) that don't
+ * live under an upstream content directory (the `_releases/` notes set no
+ * author and would otherwise inherit SITE.author). The join against resolved
+ * post paths also drops dead pre-migration `.html` URLs and non-post paths
+ * that appear in the analytics data.
+ *
+ * Returns an empty list — so the caller hides the section — whenever the API
+ * token is absent (local dev, fork PRs, before the secret is provisioned) or
+ * the fetch fails. A decorative widget must never break a deploy.
+ */
+export async function getPopularPosts(
+  posts: CollectionEntry<"blog">[],
+  limit = POPULAR_POST_COUNT
+): Promise<CollectionEntry<"blog">[]> {
+  if (!CLOUDFLARE_ANALYTICS_API_TOKEN) return [];
+
+  let counts: Map<string, number>;
+  try {
+    counts = await fetchPathCounts();
+  } catch {
+    return [];
+  }
+
+  return posts
+    .filter(postFilter)
+    .filter(post => post.data.author === SITE.author)
+    .filter(post => !isUpstream(post.filePath))
+    .map(post => ({
+      post,
+      count: counts.get(normalizePath(getPath(post.id, post.filePath))) ?? 0,
+    }))
+    .filter(({ count }) => count > 0)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit)
+    .map(({ post }) => post);
+}


### PR DESCRIPTION
## Summary

Ships the first of #142's candidate features: a homepage **Popular** section
(top five of the author's own posts by page views over a rolling 90 days),
between Featured and Recent. Counts come from the Cloudflare Web Analytics RUM
dataset at build time and drive ranking only — no figures are shown, because
RUM counts are adaptively sampled and arrive rounded to tens.

## Gotchas

- **Needs a new secret before it does anything.** #141 shipped only the public
  beacon; the GraphQL Analytics API needs a scoped token (**Account Analytics →
  Read**) added as the `CLOUDFLARE_ANALYTICS_API_TOKEN` repo secret. Until then
  the section is omitted — the token is optional and any absence/error degrades
  to no widget, so this merges dormant and lights up once provisioned. Hence
  `Refs #142`, not `Closes` — close after provisioning and verifying live.
- **Two filters, not one.** Eligibility is the author's own writing. Guest
  tutorials carry a foreign `author`, but the `_releases/` notes set none and
  inherit `SITE.author`, so `astro-paper-v5` (currently the busiest post path)
  would rank on the author filter alone — an explicit upstream-directory
  exclusion is also required. `_hakyll`/`_nikola` are restored *author* posts
  and stay eligible.
- Refresh rides the existing 6-hourly webmention cron; no new schedule.
- Known limitation: reads on legacy `.html` URLs of restored posts don't join
  to the canonical `/posts/<slug>/` path, so those posts under-count for now.

## Verification

- `pnpm lint` clean; `pnpm build` (`astro check` 0 errors) builds 62 pages.
- Token absent → section omitted; under-scoped token (live authz error) →
  section omitted, build still green (exercised end-to-end locally).
- Query + account tag confirmed against the live RUM dataset; joined the real
  90-day data against the collection — yields `i-built-the-machine-twice` and
  `how-i-back-up`, with `_releases`/`examples`/`.html` paths correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkPCCCJDiaUXr8DjaaX4m5