### PR TITLE
Gate slug page on postFilter to hide scheduled posts

### DIFF
--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -2,6 +2,7 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import PostDetails from "@/layouts/PostDetails.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
+import postFilter from "@/utils/postFilter";
 import { getPath } from "@/utils/getPath";
 
 type Props = {
@@ -9,7 +10,7 @@ type Props = {
 };
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  const posts = await getCollection("blog", postFilter);
   const postResult = posts.map(post => ({
     params: { slug: getPath(post.id, post.filePath, false) },
     props: { post },


### PR DESCRIPTION
## Summary

Filter the `[...slug]` page's `getStaticPaths` with `postFilter` instead
of `!data.draft`, so scheduled posts (non-draft, future `pubDatetime`)
are no longer URL-reachable on the deployed site — matching listings,
tag pages, and search.

## Gotchas

Previously a scheduled post's page was still built and deployed while
its tag pages were not, so it rendered real 404 links to `/tags/`.
This realigns with current AstroPaper upstream: its v5+ slug page
already routes `getStaticPaths` through `getSortedPosts`/`postFilter`.
The `!data.draft`-only filter we carry is v4-era; this isn't a
divergence but a backport. `postFilter` allows `import.meta.env.DEV`,
so `pnpm dev` still previews scheduled posts.

## Verification

`pnpm build` — scheduled posts (`how-i-recover`, `how-hard-is-this-to-undo`)
produce no `dist/posts/<slug>/`; the published `how-i-read-eight-years-on`
still builds and its unique `/tags/memory/` link resolves.

Closes #171