### PR TITLE
Off the Desk: why I left Copilot for Claude (#232)

### DIFF
--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -10,6 +10,9 @@ Naing
 
 # Tooling and platforms
 GitHub
+Claude
+Copilot
+GrafanaCON
 Replit
 bobbit
 Hakyll

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -12,6 +12,7 @@ Naing
 GitHub
 Claude
 Copilot
+Anthropic
 GrafanaCON
 Replit
 bobbit

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -149,6 +149,7 @@ filesystem
 reflash
 configs
 autocomplete
+wifi
 
 # Traditional possessive forms (singular noun ending in s + 's per
 # CMOS). Hunspell affix rules don't generate these; add each variant

--- a/.vale/styles/config/vocabularies/Custom/accept.txt
+++ b/.vale/styles/config/vocabularies/Custom/accept.txt
@@ -145,6 +145,7 @@ Tailscale
 filesystem
 reflash
 configs
+autocomplete
 
 # Traditional possessive forms (singular noun ending in s + 's per
 # CMOS). Hunspell affix rules don't generate these; add each variant

--- a/lychee.toml
+++ b/lychee.toml
@@ -27,4 +27,5 @@ exclude_path = [
   "(^|/)src/data/blog/how-i-back-up\\.md$",
   "(^|/)src/data/blog/i-built-the-machine-twice\\.md$",
   "(^|/)src/data/blog/the-bottleneck-isnt-the-blank-page\\.md$",
+  "(^|/)src/data/blog/off-the-desk\\.md$",
 ]

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -64,12 +64,3 @@ Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
 2. Starting a new plate is frictionless now — from a phone, a plane, a queue.
 3. I don't drop them: I circle back and check, and that check keeps me at the edge of what I can handle, never past it.
 4. But the edge is where I now live — the meter came off the money and reattached to me; the toil I meant to reduce just expanded to fill everything I can hold.
-
-## Open
-
-- Confirm scene 6's honest gap — the meter reattaching to *you* (permanent
-  edge; reduced toil that never arrived because the work expands to fill
-  capacity). Is that the true limitation, or does it overreach?
-- Resolved from review: scene 1 is the realistic chat + prompt-library
-  opposite; the switch was a clean break (no lingering-Copilot beat);
-  genshin.dungeon.studio named in-body.

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -3,10 +3,10 @@
 *(Working title — real title chosen in post-draft once the prose settles
 what it argues.)*
 
-**Logline.** Copilot's premium-request meter had been pricing me out at
-the rate I wanted to build, so at GrafanaCON I tried the Claude
-subscription only because I used the Claude models anyway — and on the
-plane home, planning projects from my phone through Claude chats, I
+**Logline.** Copilot's per-request billing had grown tighter than even
+the hundred-a-month budget I was glad to pay, so at GrafanaCON I tried the
+Claude subscription only because I used the Claude models anyway — and on
+the plane home, planning projects from my phone through Claude chats, I
 realised it wasn't a cheaper Copilot but a different medium: the work had
 left the editor, and I could spin many plates again instead of pouring
 everything into one. The one moment of change is that recognition on the
@@ -14,7 +14,7 @@ plane. It opens at its opposite: productive but desk-bound, one project
 soaking up everything, on a meter.
 
 **How it discharges #232.** The issue's frame is "cost as the constraint
-nobody budgeted." Cost is the *push* (Copilot's premium-request overages)
+nobody budgeted." Cost is the *push* (the per-request budget that ran tight)
 and, at the close, the dollar bill I *dodged* (Copilot went fully
 per-token days after I left — the bill the whole discourse now argues
 about) sets up the real bill nobody budgets: not dollars but capacity.
@@ -34,16 +34,17 @@ Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
 2. It was genuinely productive — but that one project soaked up nearly all of it *(~85–97 commits/month, Feb–Apr)*.
 3. It lived at the desk, in the IDE's chat panel, and my attention lived on that one plate.
 
-## 2. The meter I couldn't afford — *the forcing function*
+## 2. The budget that ran tight — *the forcing function*
 
-1. Copilot billed premium requests — a monthly allowance, then per-request overage *(github.blog changelog 2025-06-18; $0.04/request)*.
-2. At the rate I built, the allowance vanished and the overages made it a meter I couldn't afford.
-3. I wasn't going to pay by the request to work at the pace I wanted.
+1. Copilot billed by the premium request — a set number each month, then a charge past that *(github.blog changelog 2025-06-18; $0.04/request)*.
+2. The models I leaned on burned that number fast, so my own cap was the real limit: a hundred dollars a month, which I was glad to pay *(lived; Claude models carried high request-multipliers — the no-allowance, pure-per-token move is dated 2026-06-01, after the switch)*.
+3. At my pace even that ran tight, and by spring it wasn't enough.
 
 ## 3. GrafanaCON, on low expectations — *the reluctant step*
 
-1. At GrafanaCON in Barcelona I tried the Claude subscription *(2026-04-20/22)*.
-2. I only used the Claude models anyway — a lateral, cost-driven move, expecting a cheaper version of what I had.
+1. At GrafanaCON in Barcelona I tried the Claude subscription — I used the Claude models anyway *(2026-04-20/22)*.
+2. A flat rate put the per-token charge out of my life, and that relief alone was what I'd come for.
+3. I expected a cheaper version of what I already had, nothing more.
 
 ## 4. On the plane home — *the turn (the one moment of change)*
 

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -49,7 +49,7 @@ trigger; that instinct pays off in scene 6's edge.
 ## 3. GrafanaCON, on low expectations — *the reluctant step*
 
 1. That same week I was at GrafanaCON in Barcelona and tried the Claude subscription — the model I already used, bought straight from its makers *(GrafanaCON 2026-04-20/22, same week as the plan change)*.
-2. The Claude models sat inside one flat monthly price again, and that relief was all I'd come for.
+2. It put my model back at one flat monthly price — the sensible swap.
 3. I expected a cheaper version of what I already had, nothing more.
 
 ## 4. On the plane home — *the turn (the one moment of change)*

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -4,7 +4,7 @@
 what it argues.)*
 
 **Logline.** Copilot's per-request billing had grown tighter than even
-the hundred-a-month budget I was glad to pay, so at GrafanaCON I tried the
+the budget I was glad to pay, so at GrafanaCON I tried the
 Claude subscription only because I used the Claude models anyway — and on
 the plane home, planning projects from my phone through Claude chats, I
 realised it wasn't a cheaper Copilot but a different medium: the work had
@@ -37,7 +37,7 @@ Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
 ## 2. The budget that ran tight — *the forcing function*
 
 1. Copilot billed by the premium request — a set number each month, then a charge past that *(github.blog changelog 2025-06-18; $0.04/request)*.
-2. The models I leaned on burned that number fast, so my own cap was the real limit: a hundred dollars a month, which I was glad to pay *(lived; Claude models carried high request-multipliers — the no-allowance, pure-per-token move is dated 2026-06-01, after the switch)*.
+2. The models I leaned on burned that number fast, so my own cap was the real limit — a monthly budget I was glad to pay *(lived; keep the figure out; Claude models carried high request-multipliers — the no-allowance, pure-per-token move is dated 2026-06-01, after the switch)*.
 3. At my pace even that ran tight, and by spring it wasn't enough.
 
 ## 3. GrafanaCON, on low expectations — *the reluctant step*

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -1,0 +1,79 @@
+# Off the Desk — outline
+
+*(Working title — real title chosen in post-draft once the prose settles
+what it argues.)*
+
+**Logline.** Copilot's premium-request billing had been pricing me out at
+the rate I wanted to build, so at GrafanaCON I tried the Claude
+subscription only because I used the Claude models anyway — and on the
+plane home, planning projects over the wifi through Claude chats, I
+realised it wasn't a cheaper Copilot but a different medium: the work had
+left the editor. The one moment of change is that recognition on the
+plane. It opens at its opposite: bound to a single pane in VSCode.
+
+**How it discharges #232.** The issue's frame is "cost as the constraint
+nobody budgeted." Cost is the *push* (Copilot's premium-request overages,
+the forcing function) and, at the close, it reappears as the *real* bill
+nobody budgeted — not dollars but attention: the phone made starting
+anything frictionless, and friction was doing work. The durable claim
+under the news hook isn't the cost thesis everyone's already writing;
+it's that the metered bill pushed me off the desk into a way of working
+where the cost that actually comes due is the one I can't see on an
+invoice.
+
+**Register.** Narrative / reflective — continuous, no section headers,
+built to the one moment on the plane. The cost discourse (Uber caps,
+Simon's math, the Apr-27 usage-based announcement) is ambient backdrop,
+not thesis.
+
+## 1. A pane in the editor — *the opposite*
+
+1. Copilot lived in one place: a pane in VSCode, pairing as I typed.
+2. The work was desk-bound and IDE-shaped — autocomplete-plus, inside the file.
+3. That pane was the whole world of the tool; I didn't reach past it.
+
+## 2. The meter I couldn't afford — *the forcing function*
+
+1. Copilot had gone to premium-request billing — a monthly allowance, then per-request overage *(github.blog changelog, 2025-06-18; $0.04/request)*.
+2. My allowance kept evaporating; at the rate I actually built, the overages made it a meter I couldn't afford.
+3. I wasn't going to pay by the request to work at the pace I wanted.
+
+## 3. GrafanaCON, on low expectations — *the reluctant step*
+
+1. At GrafanaCON in Barcelona I tried the Claude subscription *(2026-04-20/22)*.
+2. I only used the Claude models anyway — a lateral, cost-driven move, expecting a cheaper pane.
+
+## 4. On the plane home — *the turn (the one moment of change)*
+
+1. It wasn't a cheaper Copilot — the claude.ai chats were their own thing.
+2. On the plane wifi I was planning projects through those chats — and every dusted-off side project started there.
+3. Then Claude Code, driven by remote control, with none of it tied to the editor.
+4. The work had left the desk.
+
+## 5. Rebuilding the machine — *the lift (consequence + the real cost)*
+
+1. The switch's real cost wasn't dollars — it was rebuilding my tooling around Claude: skills, Claude-specific config.
+2. Claude bootstrapped its own scaffolding — the loop is visible in the commit history *(first skill 2026-05-03)*.
+3. Days after I'd already left, Copilot announced it was going fully per-token — the bill the whole discourse now argues about, and I'd walked before it landed *(github.blog, 2026-04-27; effective 2026-06-01)*.
+4. The side-project work exploded back to life *(this repo: dormant since 2020, then 109 commits in 2026-05)* — converging systems toward reduced toil, the thing I actually chase.
+
+## 6. Starting is the easy part — *the honest gap*
+
+1. I can start anything now — from a plane seat, a train, a queue — all from the phone.
+2. But starting was never the expensive part; keeping the dusted-off projects alive is, and I blew the dust off all of them at once.
+3. The friction I removed was the friction that used to decide which projects deserved to exist — that's the bill I didn't budget for.
+
+## Open
+
+- Confirm scene 6's honest gap — is "the frictionlessness spawns more
+  than I can keep alive" the truer limitation now (non-religious, replaces
+  "grace could end")? Or does it overreach what you've actually felt yet?
+- Scene 4 order now: chats → planning on the plane wifi (dust-off starts)
+  → remote-control Claude Code last. Confirm that's the real sequence.
+- Scene 2 forcing function is the premium-request overage model
+  (2025-06-18), not the Apr-27 usage-based announcement — the latter is
+  demoted to a confirmation beat in scene 5 because it postdates your
+  GrafanaCON switch. Confirm that ordering matches your memory.
+- Optional dev-reaction texture for scene 2 (Visual Studio Magazine's
+  "you will get less, pay the same price") if the forcing function wants a
+  second citation; the github.blog changelog is enough alone.

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -19,9 +19,9 @@ plans: it dropped the Claude models from what the plan covered, and since
 Claude was the only model I used, the plan had become a middle layer I no
 longer needed — so I went direct. That's the cost reckoning landing on an
 individual, but the *real* bill nobody budgets, at the close, isn't dollars
-— it's capacity. The meter came off the money and reattached to me: I live
-at the edge of what I can handle, and the toil I meant to reduce just
-expanded to fill it. The durable claim under the news hook isn't the cost
+— it's capacity. Money was never my constraint; the bill nobody budgets,
+for me, is how much I can hold at once — I live at the edge of it, and the
+toil I meant to reduce just expanded to fill it. The durable claim under the news hook isn't the cost
 thesis everyone's writing; it's that the change pushed me off the desk into
 a way of working whose true cost never shows up on an invoice.
 
@@ -71,7 +71,7 @@ edge.
 
 ## 6. The bill I didn't budget — *the honest gap*
 
-1. The talk now is all about the cost — what these tools run, who can afford them *(ambient discourse: Uber caps, Willison; no timeline claim)*.
-2. A bill came due for me too, but not in dollars: starting anything is frictionless now — a chat from a queue or a train.
-3. I don't drop them; I come back and check, and that keeps me at the edge of what I can carry, never past it.
-4. The meter I ran from was money; the one that replaced it is me — I set out to spend less effort, and the work grew to fill all I had.
+1. The talk is all about the dollar cost — what these tools run, who can afford them *(ambient discourse: Uber caps, Willison; no timeline claim)*.
+2. I watch what I spend, but money was never my limit; my limit is how much I can hold at once *(the #232 discharge: the constraint nobody budgets, for me, is capacity — not dollars)*.
+3. Starting is frictionless now — a project going from a queue or a train, in idle time; I keep track of them, come back and check, and that holds me at the edge of what I can carry, never quite past it.
+4. The edge is where I live: I meant for the work to take less out of me; instead it grew to fill whatever I could give it.

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -3,77 +3,73 @@
 *(Working title — real title chosen in post-draft once the prose settles
 what it argues.)*
 
-**Logline.** Copilot's premium-request billing had been pricing me out at
+**Logline.** Copilot's premium-request meter had been pricing me out at
 the rate I wanted to build, so at GrafanaCON I tried the Claude
 subscription only because I used the Claude models anyway — and on the
-plane home, planning projects over the wifi through Claude chats, I
+plane home, planning projects from my phone through Claude chats, I
 realised it wasn't a cheaper Copilot but a different medium: the work had
-left the editor. The one moment of change is that recognition on the
-plane. It opens at its opposite: bound to a single pane in VSCode.
+left the editor, and I could spin many plates again instead of pouring
+everything into one. The one moment of change is that recognition on the
+plane. It opens at its opposite: productive but desk-bound, one project
+soaking up everything, on a meter.
 
 **How it discharges #232.** The issue's frame is "cost as the constraint
-nobody budgeted." Cost is the *push* (Copilot's premium-request overages,
-the forcing function) and, at the close, it reappears as the *real* bill
-nobody budgeted — not dollars but attention: the phone made starting
-anything frictionless, and friction was doing work. The durable claim
-under the news hook isn't the cost thesis everyone's already writing;
-it's that the metered bill pushed me off the desk into a way of working
-where the cost that actually comes due is the one I can't see on an
-invoice.
+nobody budgeted." Cost is the *push* (Copilot's premium-request overages)
+and, at the close, the dollar bill I *dodged* (Copilot went fully
+per-token days after I left — the bill the whole discourse now argues
+about) sets up the real bill nobody budgets: not dollars but capacity.
+The meter came off the money and reattached to me — I live at the edge of
+what I can handle, and the toil I meant to reduce just expanded to fill
+it. The durable claim under the news hook isn't the cost thesis everyone's
+writing; it's that the metered bill pushed me off the desk into a way of
+working whose true cost never shows up on an invoice.
 
 **Register.** Narrative / reflective — continuous, no section headers,
 built to the one moment on the plane. The cost discourse (Uber caps,
-Simon's math, the Apr-27 usage-based announcement) is ambient backdrop,
-not thesis.
+Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
 
-## 1. A pane in the editor — *the opposite*
+## 1. One plate, at the desk — *the opposite*
 
-1. Copilot lived in one place: a pane in VSCode, pairing as I typed.
-2. The work was desk-bound and IDE-shaped — autocomplete-plus, inside the file.
-3. That pane was the whole world of the tool; I didn't reach past it.
+1. Copilot was chat for me — I drove it through a prompt library I'd built up in genshin.dungeon.studio: instructions, prompt files, the lot *(from 2026-01-26)*.
+2. It was genuinely productive — but that one project soaked up nearly all of it *(~85–97 commits/month, Feb–Apr)*.
+3. It lived at the desk, in the IDE's chat panel, and my attention lived on that one plate.
 
 ## 2. The meter I couldn't afford — *the forcing function*
 
-1. Copilot had gone to premium-request billing — a monthly allowance, then per-request overage *(github.blog changelog, 2025-06-18; $0.04/request)*.
-2. My allowance kept evaporating; at the rate I actually built, the overages made it a meter I couldn't afford.
+1. Copilot billed premium requests — a monthly allowance, then per-request overage *(github.blog changelog 2025-06-18; $0.04/request)*.
+2. At the rate I built, the allowance vanished and the overages made it a meter I couldn't afford.
 3. I wasn't going to pay by the request to work at the pace I wanted.
 
 ## 3. GrafanaCON, on low expectations — *the reluctant step*
 
 1. At GrafanaCON in Barcelona I tried the Claude subscription *(2026-04-20/22)*.
-2. I only used the Claude models anyway — a lateral, cost-driven move, expecting a cheaper pane.
+2. I only used the Claude models anyway — a lateral, cost-driven move, expecting a cheaper version of what I had.
 
 ## 4. On the plane home — *the turn (the one moment of change)*
 
-1. It wasn't a cheaper Copilot — the claude.ai chats were their own thing.
-2. On the plane wifi I was planning projects through those chats — and every dusted-off side project started there.
-3. Then Claude Code, driven by remote control, with none of it tied to the editor.
+1. I already had chat — what I didn't have was chat off the desk.
+2. On the plane wifi I was planning projects from my phone, through Claude chats.
+3. Then Claude Code by remote control — none of it tied to the editor.
 4. The work had left the desk.
 
-## 5. Rebuilding the machine — *the lift (consequence + the real cost)*
+## 5. Spinning the plates again — *the lift (consequence + the real cost)*
 
-1. The switch's real cost wasn't dollars — it was rebuilding my tooling around Claude: skills, Claude-specific config.
-2. Claude bootstrapped its own scaffolding — the loop is visible in the commit history *(first skill 2026-05-03)*.
-3. Days after I'd already left, Copilot announced it was going fully per-token — the bill the whole discourse now argues about, and I'd walked before it landed *(github.blog, 2026-04-27; effective 2026-06-01)*.
-4. The side-project work exploded back to life *(this repo: dormant since 2020, then 109 commits in 2026-05)* — converging systems toward reduced toil, the thing I actually chase.
+1. The change wasn't more output — it was more plates: many projects moving at once, not one soaking up everything.
+2. Dormant projects woke as new plates — this blog among them *(dormant since 2020, then 109 commits in 2026-05)*.
+3. The real cost was rebuilding tooling around Claude — skills, CLAUDE.md — which Claude itself bootstrapped *(genshin CLAUDE.md 2026-04-24; first blog skill 2026-05-03)*.
 
-## 6. Starting is the easy part — *the honest gap*
+## 6. The bill I didn't budget — *the honest gap*
 
-1. I can start anything now — from a plane seat, a train, a queue — all from the phone.
-2. But starting was never the expensive part; keeping the dusted-off projects alive is, and I blew the dust off all of them at once.
-3. The friction I removed was the friction that used to decide which projects deserved to exist — that's the bill I didn't budget for.
+1. Days after I left, Copilot went fully per-token — I'd walked before the dollar bill the whole discourse now argues about *(github.blog 2026-04-27; effective 2026-06-01)*.
+2. Starting a new plate is frictionless now — from a phone, a plane, a queue.
+3. I don't drop them: I circle back and check, and that check keeps me at the edge of what I can handle, never past it.
+4. But the edge is where I now live — the meter came off the money and reattached to me; the toil I meant to reduce just expanded to fill everything I can hold.
 
 ## Open
 
-- Confirm scene 6's honest gap — is "the frictionlessness spawns more
-  than I can keep alive" the truer limitation now (non-religious, replaces
-  "grace could end")? Or does it overreach what you've actually felt yet?
-- Scene 4 order now: chats → planning on the plane wifi (dust-off starts)
-  → remote-control Claude Code last. Confirm that's the real sequence.
-- Scene 2 forcing function is the premium-request overage model
-  (2025-06-18), not the Apr-27 usage-based announcement — the latter is
-  demoted to a confirmation beat in scene 5 because it postdates your
-  GrafanaCON switch. Confirm that ordering matches your memory.
-- Optional dev-reaction texture for scene 2 (Visual Studio Magazine's
-  "you will get less, pay the same price") if the forcing function wants a
-  second citation; the github.blog changelog is enough alone.
+- Confirm scene 6's honest gap — the meter reattaching to *you* (permanent
+  edge; reduced toil that never arrived because the work expands to fill
+  capacity). Is that the true limitation, or does it overreach?
+- Resolved from review: scene 1 is the realistic chat + prompt-library
+  opposite; the switch was a clean break (no lingering-Copilot beat);
+  genshin.dungeon.studio named in-body.

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -3,9 +3,10 @@
 *(Working title — real title chosen in post-draft once the prose settles
 what it argues.)*
 
-**Logline.** Copilot's per-request billing had grown tighter than even
-the budget I was glad to pay, so at GrafanaCON I tried the
-Claude subscription only because I used the Claude models anyway — and on
+**Logline.** GitHub's April change to its individual Copilot plans capped
+my weekly usage below the pace I was glad to pay for, so that same week at
+GrafanaCON I tried the Claude subscription only because I used the Claude
+models anyway — and on
 the plane home, planning projects from my phone through Claude chats, I
 realised it wasn't a cheaper Copilot but a different medium: the work had
 left the editor, and I could spin many plates again instead of pouring
@@ -14,19 +15,22 @@ plane. It opens at its opposite: productive but desk-bound, one project
 soaking up everything, on a meter.
 
 **How it discharges #232.** The issue's frame is "cost as the constraint
-nobody budgeted." Cost is the *push* (the per-request budget that ran tight)
-and, at the close, the dollar bill I *dodged* (Copilot went fully
-per-token days after I left — the bill the whole discourse now argues
-about) sets up the real bill nobody budgets: not dollars but capacity.
-The meter came off the money and reattached to me — I live at the edge of
-what I can handle, and the toil I meant to reduce just expanded to fill
-it. The durable claim under the news hook isn't the cost thesis everyone's
-writing; it's that the metered bill pushed me off the desk into a way of
-working whose true cost never shows up on an invoice.
+nobody budgeted." Cost is the *push* (GitHub's April cap on individual
+plans, which throttled the pace I was glad to pay for) and, at the close, the *real* bill nobody
+budgets: not dollars but capacity. The meter came off the money and
+reattached to me — I live at the edge of what I can handle, and the toil I
+meant to reduce just expanded to fill it. The durable claim under the news
+hook isn't the cost thesis everyone's writing; it's that the pricing change
+pushed me off the desk into a way of working whose true cost never shows up
+on an invoice.
 
 **Register.** Narrative / reflective — continuous, no section headers,
 built to the one moment on the plane. The cost discourse (Uber caps,
-Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
+Simon's math) is ambient backdrop, referenced without a timeline claim.
+The forcing function is dated and cited: GitHub's 2026-04-20 changes to
+individual Copilot plans (weekly token caps; Opus pulled from Pro but kept
+in Pro+). The author was on Pro+, so the weekly cap is the beat, not the
+Opus removal.
 
 ## 1. One plate, at the desk — *the opposite*
 
@@ -34,15 +38,15 @@ Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
 2. It was genuinely productive — but that one project soaked up nearly all of it *(~85–97 commits/month, Feb–Apr)*.
 3. It lived at the desk, in the IDE's chat panel, and my attention lived on that one plate.
 
-## 2. The budget that ran tight — *the forcing function*
+## 2. The weekly cap — *the forcing function*
 
-1. Copilot billed by the premium request — a set number each month, then a charge past that *(github.blog changelog 2025-06-18; $0.04/request)*.
-2. The models I leaned on burned that number fast, so my own cap was the real limit — a monthly budget I was glad to pay *(lived; keep the figure out; Claude models carried high request-multipliers — the no-allowance, pure-per-token move is dated 2026-06-01, after the switch)*.
-3. At my pace even that ran tight, and by spring it wasn't enough.
+1. GitHub changed its individual Copilot plans, putting a weekly cap on how much I could run *(github.blog, changes-to-github-copilot-individual-plans, 2026-04-20; weekly token-consumption caps)*.
+2. I was on the top tier and glad to pay for it, but at my pace the cap ran out well before the week did *(Pro+; keep the budget figure out)*.
+3. That change was the trigger; it sent me looking for another way to work.
 
 ## 3. GrafanaCON, on low expectations — *the reluctant step*
 
-1. At GrafanaCON in Barcelona I tried the Claude subscription — I used the Claude models anyway *(2026-04-20/22)*.
+1. That same week I was at GrafanaCON in Barcelona and tried the Claude subscription — I used the Claude models anyway *(GrafanaCON 2026-04-20/22, same week as the plan change)*.
 2. A flat rate put the per-token charge out of my life, and that relief alone was what I'd come for.
 3. I expected a cheaper version of what I already had, nothing more.
 
@@ -61,7 +65,7 @@ Simon's math, the Apr-27 usage-based announcement) is ambient backdrop.
 
 ## 6. The bill I didn't budget — *the honest gap*
 
-1. Days after I left, Copilot went fully per-token — I'd walked before the dollar bill the whole discourse now argues about *(github.blog 2026-04-27; effective 2026-06-01)*.
-2. Starting a new plate is frictionless now — from a phone, a plane, a queue.
-3. I don't drop them: I circle back and check, and that check keeps me at the edge of what I can handle, never past it.
-4. But the edge is where I now live — the meter came off the money and reattached to me; the toil I meant to reduce just expanded to fill everything I can hold.
+1. The talk now is all about the cost — what these tools run, who can afford them *(ambient discourse: Uber caps, Willison; no timeline claim)*.
+2. A bill came due for me too, but not in dollars: starting anything is frictionless now — a chat from a queue or a train.
+3. I don't drop them; I come back and check, and that keeps me at the edge of what I can carry, never past it.
+4. The meter I ran from was money; the one that replaced it is me — I set out to spend less effort, and the work grew to fill all I had.

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -3,10 +3,10 @@
 *(Working title — real title chosen in post-draft once the prose settles
 what it argues.)*
 
-**Logline.** GitHub's April change to its individual Copilot plans stopped
-including the Claude models I used — every token now came out of budget —
-so rather than pay for a plan without my one model, that same week at
-GrafanaCON I tried the Claude subscription. On the plane home, planning
+**Logline.** GitHub's April change to its individual Copilot plans dropped
+the Claude models I used; since Claude was the only model I ever reached
+for, the plan had become a middle layer I no longer needed, so that same
+week at GrafanaCON I went to Claude direct. On the plane home, planning
 projects from my phone through Claude chats, I realised it wasn't a cheaper
 Copilot but a different medium: the work had left the editor, and I could
 spin many plates again instead of pouring everything into one. The one
@@ -14,25 +14,29 @@ moment of change is that recognition on the plane. It opens at its
 opposite: productive but desk-bound, one project soaking up everything.
 
 **How it discharges #232.** The issue's frame is "cost as the constraint
-nobody budgeted." Cost is the *push* (GitHub's April change dropped the
-Claude models from what my plan included, so paying Copilot for a plan
-without my one model stopped making sense) and, at the close, the *real* bill nobody
-budgets: not dollars but capacity. The meter came off the money and
-reattached to me — I live at the edge of what I can handle, and the toil I
-meant to reduce just expanded to fill it. The durable claim under the news
-hook isn't the cost thesis everyone's writing; it's that the pricing change
-pushed me off the desk into a way of working whose true cost never shows up
-on an invoice.
+nobody budgeted." The *push* is GitHub's April change to individual Copilot
+plans: it dropped the Claude models from what the plan covered, and since
+Claude was the only model I used, the plan had become a middle layer I no
+longer needed — so I went direct. That's the cost reckoning landing on an
+individual, but the *real* bill nobody budgets, at the close, isn't dollars
+— it's capacity. The meter came off the money and reattached to me: I live
+at the edge of what I can handle, and the toil I meant to reduce just
+expanded to fill it. The durable claim under the news hook isn't the cost
+thesis everyone's writing; it's that the change pushed me off the desk into
+a way of working whose true cost never shows up on an invoice.
 
 **Register.** Narrative / reflective — continuous, no section headers,
 built to the one moment on the plane. The cost discourse (Uber caps,
 Simon's math) is ambient backdrop, referenced without a timeline claim.
 The forcing function is dated and cited: GitHub's 2026-04-20 changes to
 individual Copilot plans. Author was on Pro+; the beat is that the change
-left the Claude models out of what the plan included (all budget), so
-paying for a plan without his one model made no sense — go to the model's
-own plan. The cap he'd always hit was welcome back-pressure, not the
-trigger; that instinct pays off in scene 6's edge.
+dropped the Claude models from what the plan covered, and since Claude was
+the only model he used, Copilot had become a middle layer with nothing left
+to offer — so he went direct to Anthropic. Keep money accounting out of the
+prose (subscription-vs-usage, budget, price comparison all mislead — the
+two products differ in price and access). The cap he'd always hit was
+welcome back-pressure, not the trigger; that instinct pays off in scene 6's
+edge.
 
 ## 1. One plate, at the desk — *the opposite*
 
@@ -40,16 +44,16 @@ trigger; that instinct pays off in scene 6's edge.
 2. It was genuinely productive — but that one project soaked up nearly all of it *(~85–97 commits/month, Feb–Apr)*.
 3. It lived at the desk, in the IDE's chat panel, and my attention lived on that one plate.
 
-## 2. Why pay for a plan without my model — *the forcing function*
+## 2. The aggregator I no longer needed — *the forcing function*
 
-1. GitHub changed its individual Copilot plans; even on the top tier, the Claude models were no longer included — every token I spent on them came out of budget *(github.blog, changes-to-github-copilot-individual-plans, 2026-04-20; author's Pro+ billing)*.
-2. Claude was the only model I reached for, so paying for a plan that no longer covered it stopped making sense.
-3. If I was buying those tokens anyway, I could buy them from the people who made the model — the nudge to try something else.
+1. GitHub changed its individual Copilot plans; even on the top tier, the Claude models dropped out of what it included *(github.blog, changes-to-github-copilot-individual-plans, 2026-04-20; author on Pro+)*.
+2. Copilot's value was the spread of models it offered, and Claude was the only one I ever used — with it out of the plan, the middle layer had nothing left to give me.
+3. I could get Claude straight from Anthropic; that was the nudge to go direct.
 
 ## 3. GrafanaCON, on low expectations — *the reluctant step*
 
-1. That same week I was at GrafanaCON in Barcelona and tried the Claude subscription — the model I already used, bought straight from its makers *(GrafanaCON 2026-04-20/22, same week as the plan change)*.
-2. It put my model back at one flat monthly price — the sensible swap.
+1. That same week I was at GrafanaCON in Barcelona and tried the Claude subscription *(GrafanaCON 2026-04-20/22, same week as the plan change)*.
+2. It came at one flat price a month — the sensible swap I'd acted on.
 3. I expected a cheaper version of what I already had, nothing more.
 
 ## 4. On the plane home — *the turn (the one moment of change)*

--- a/outlines/off-the-desk.md
+++ b/outlines/off-the-desk.md
@@ -3,20 +3,20 @@
 *(Working title — real title chosen in post-draft once the prose settles
 what it argues.)*
 
-**Logline.** GitHub's April change to its individual Copilot plans capped
-my weekly usage below the pace I was glad to pay for, so that same week at
-GrafanaCON I tried the Claude subscription only because I used the Claude
-models anyway — and on
-the plane home, planning projects from my phone through Claude chats, I
-realised it wasn't a cheaper Copilot but a different medium: the work had
-left the editor, and I could spin many plates again instead of pouring
-everything into one. The one moment of change is that recognition on the
-plane. It opens at its opposite: productive but desk-bound, one project
-soaking up everything, on a meter.
+**Logline.** GitHub's April change to its individual Copilot plans stopped
+including the Claude models I used — every token now came out of budget —
+so rather than pay for a plan without my one model, that same week at
+GrafanaCON I tried the Claude subscription. On the plane home, planning
+projects from my phone through Claude chats, I realised it wasn't a cheaper
+Copilot but a different medium: the work had left the editor, and I could
+spin many plates again instead of pouring everything into one. The one
+moment of change is that recognition on the plane. It opens at its
+opposite: productive but desk-bound, one project soaking up everything.
 
 **How it discharges #232.** The issue's frame is "cost as the constraint
-nobody budgeted." Cost is the *push* (GitHub's April cap on individual
-plans, which throttled the pace I was glad to pay for) and, at the close, the *real* bill nobody
+nobody budgeted." Cost is the *push* (GitHub's April change dropped the
+Claude models from what my plan included, so paying Copilot for a plan
+without my one model stopped making sense) and, at the close, the *real* bill nobody
 budgets: not dollars but capacity. The meter came off the money and
 reattached to me — I live at the edge of what I can handle, and the toil I
 meant to reduce just expanded to fill it. The durable claim under the news
@@ -28,9 +28,11 @@ on an invoice.
 built to the one moment on the plane. The cost discourse (Uber caps,
 Simon's math) is ambient backdrop, referenced without a timeline claim.
 The forcing function is dated and cited: GitHub's 2026-04-20 changes to
-individual Copilot plans (weekly token caps; Opus pulled from Pro but kept
-in Pro+). The author was on Pro+, so the weekly cap is the beat, not the
-Opus removal.
+individual Copilot plans. Author was on Pro+; the beat is that the change
+left the Claude models out of what the plan included (all budget), so
+paying for a plan without his one model made no sense — go to the model's
+own plan. The cap he'd always hit was welcome back-pressure, not the
+trigger; that instinct pays off in scene 6's edge.
 
 ## 1. One plate, at the desk — *the opposite*
 
@@ -38,16 +40,16 @@ Opus removal.
 2. It was genuinely productive — but that one project soaked up nearly all of it *(~85–97 commits/month, Feb–Apr)*.
 3. It lived at the desk, in the IDE's chat panel, and my attention lived on that one plate.
 
-## 2. The weekly cap — *the forcing function*
+## 2. Why pay for a plan without my model — *the forcing function*
 
-1. GitHub changed its individual Copilot plans, putting a weekly cap on how much I could run *(github.blog, changes-to-github-copilot-individual-plans, 2026-04-20; weekly token-consumption caps)*.
-2. I was on the top tier and glad to pay for it, but at my pace the cap ran out well before the week did *(Pro+; keep the budget figure out)*.
-3. That change was the trigger; it sent me looking for another way to work.
+1. GitHub changed its individual Copilot plans; even on the top tier, the Claude models were no longer included — every token I spent on them came out of budget *(github.blog, changes-to-github-copilot-individual-plans, 2026-04-20; author's Pro+ billing)*.
+2. Claude was the only model I reached for, so paying for a plan that no longer covered it stopped making sense.
+3. If I was buying those tokens anyway, I could buy them from the people who made the model — the nudge to try something else.
 
 ## 3. GrafanaCON, on low expectations — *the reluctant step*
 
-1. That same week I was at GrafanaCON in Barcelona and tried the Claude subscription — I used the Claude models anyway *(GrafanaCON 2026-04-20/22, same week as the plan change)*.
-2. A flat rate put the per-token charge out of my life, and that relief alone was what I'd come for.
+1. That same week I was at GrafanaCON in Barcelona and tried the Claude subscription — the model I already used, bought straight from its makers *(GrafanaCON 2026-04-20/22, same week as the plan change)*.
+2. The Claude models sat inside one flat monthly price again, and that relief was all I'd come for.
 3. I expected a cheaper version of what I already had, nothing more.
 
 ## 4. On the plane home — *the turn (the one moment of change)*

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -16,17 +16,16 @@ hundred commits, and that one
 project took most of them. The chat sat in a panel next to the code, in the
 editor, on my desk.
 
-Then, in April, GitHub [changed its individual Copilot plans][copilot-plans].
-Even on the top tier, none of the Claude models were included any more; every
-token I spent on them came out of my own budget. And Claude was the only model I
-reached for. Paying GitHub for a plan that no longer covered the one model I used
-stopped making sense. If I was buying those tokens anyway, I could buy them from
-the people who made the model.
+Then, in April, GitHub [changed its individual Copilot plans][copilot-plans], and
+the Claude models were no longer part of what the top tier included. But Claude
+was the only model I ever reached for. Copilot's value was the spread of models
+it offered, and I only wanted one of them. Once that one dropped out of the plan,
+there was no reason left to go through it. I could get Claude straight from
+Anthropic.
 
 That same week I was at GrafanaCON in Barcelona, and I tried the Claude
-subscription. It was the model I already used, so it was a small thing to try. It
-came at one flat price a month. I expected a cheaper version of what I had, and
-little more.
+subscription. It came at one flat price a month. I expected a cheaper version of
+what I had, and little more.
 
 Then I flew home. On the plane, over the wifi, I opened the chats on my phone
 and planned projects. I wasn't writing code, only thinking through what to build

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -17,6 +17,11 @@ editor, on my desk.
 
 By the time I was building this way, GitHub billed Copilot by the premium
 request. Each plan came with a set number every month, and past that they
-charged for each one. The models I leaned on spent that number quickly, so the
+charged for each one. The models I leaned on burned through that number, so the
 real limit was the budget I set for myself. I was glad to pay it. At my pace
 even that ran tight, and by the spring it wasn't enough.
+
+In April I was at GrafanaCON in Barcelona, and I tried the Claude subscription.
+I was on the Claude models anyway, so it was a small thing to try. A flat rate
+put the per-token charge out of my life, and that relief was all I'd come for. I
+expected a cheaper version of what I already had, and little more.

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -1,7 +1,7 @@
 ---
 pubDatetime: 2026-07-26T07:00:00Z
 title: Off the Desk
-description: "GitHub dropped my one model from Copilot. I went to Claude, and the work left the desk, run from my phone."
+description: "GitHub dropped my one model from Copilot. I went to Claude, and the work came off the desk onto my phone."
 tags:
   - agentic-coding
   - tooling

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -24,9 +24,9 @@ stopped making sense. If I was buying those tokens anyway, I could buy them from
 the people who made the model.
 
 That same week I was at GrafanaCON in Barcelona, and I tried the Claude
-subscription. It was the model I already used, so it was a small thing to try. On
-the subscription it came at one flat price a month, and that relief was all I'd
-come for. I expected a cheaper version of what I already had, and little more.
+subscription. It was the model I already used, so it was a small thing to try. It
+came at one flat price a month. I expected a cheaper version of what I had, and
+little more.
 
 Then I flew home. On the plane, over the wifi, I opened the chats on my phone
 and planned projects. I wasn't writing code, only thinking through what to build

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -53,10 +53,10 @@ after I got home.
 
 The talk now is all about the cost: what these tools run, who can afford to keep
 them going, where the spending stops. I watch what I spend, but money was never
-my limit. My limit is how much I can hold at once. I can set a new project going
-from a queue or a train, in the time I'd have spent waiting. I don't lose track
-of them; I come back, look, and pull each one along. That keeps me at the edge of
-what I can carry, and never quite past it.
+my limit. My limit is how much I can hold at once. In the time I used to spend in
+a queue or on a train, I can set a new project going. I don't lose track of them;
+I come back, look, and pull each one along. That keeps me at the edge of what I
+can carry, and never quite past it.
 
 The edge is where I live now. I meant for the work to take less out of me;
 instead it grew to fill whatever I could give it.

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -1,10 +1,11 @@
 ---
 pubDatetime: 2026-07-26T07:00:00Z
 title: Off the Desk
-description: "Provisional; finalised at the frontmatter stage once the body settles what it argues."
+description: "GitHub dropped my one model from Copilot. I went to Claude, and the work left the desk, run from my phone."
 tags:
   - agentic-coding
-  - methodology
+  - tooling
+  - decision-making
 ---
 
 For the first months of this year I built genshin.dungeon.studio with GitHub

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -52,15 +52,13 @@ next thing quicker to start. You can watch it go up in the history, a few days
 after I got home.
 
 The talk now is all about the cost: what these tools run, who can afford to keep
-them going, where the spending stops. A bill came due for me too, only not in
-dollars. Starting something costs next to nothing now. I can open a chat from a
-queue or a train and have a project underway before I reach the front. I don't
-lose track of them; I come back, look, and pull things along. That keeps me at
-the edge of what I can carry, and never quite past it.
+them going, where the spending stops. I watch what I spend, but money was never
+my limit. My limit is how much I can hold at once. I can set a new project going
+from a queue or a train, in the time I'd have spent waiting. I don't lose track
+of them; I come back, look, and pull each one along. That keeps me at the edge of
+what I can carry, and never quite past it.
 
-The edge is just where I live now. The meter I ran from was measured in money,
-and I got out from under it. The one that replaced it is measured in me. I set
-out to spend less effort, and instead the work grew until it filled everything I
-had to give.
+The edge is where I live now. I meant for the work to take less out of me;
+instead it grew to fill whatever I could give it.
 
 [copilot-plans]: https://github.blog/news-insights/company-news/changes-to-github-copilot-individual-plans/

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -1,0 +1,16 @@
+---
+pubDatetime: 2026-07-26T07:00:00Z
+title: Off the Desk
+description: "Provisional; finalised at the frontmatter stage once the body settles what it argues."
+tags:
+  - agentic-coding
+  - methodology
+---
+
+For the first months of this year I built genshin.dungeon.studio with GitHub
+Copilot. I used its chat far more than its autocomplete. There I kept a page of
+instructions and a set of prompt files. They told it how I wanted things done,
+down to commit messages and reviews. I asked, it answered, and the work moved
+fast. Some months ran to the better part of a hundred commits, and that one
+project took most of them. The chat sat in a panel next to the code, in the
+editor, on my desk.

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -14,3 +14,9 @@ down to commit messages and reviews. I asked, it answered, and the work moved
 fast. Some months ran to the better part of a hundred commits, and that one
 project took most of them. The chat sat in a panel next to the code, in the
 editor, on my desk.
+
+By the time I was building this way, GitHub billed Copilot by the premium
+request. Each plan came with a set number every month, and past that they
+charged for each one. The models I leaned on spent that number quickly, so the
+real limit was the budget I set for myself. I was glad to pay it. At my pace
+even that ran tight, and by the spring it wasn't enough.

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -8,10 +8,11 @@ tags:
 ---
 
 For the first months of this year I built genshin.dungeon.studio with GitHub
-Copilot. I used its chat far more than its autocomplete. There I kept a page of
-instructions and a set of prompt files. They told it how I wanted things done,
-down to commit messages and reviews. I asked, it answered, and the work moved
-fast. Some months ran to the better part of a hundred commits, and that one
+Copilot. I used its chat far more than its autocomplete. I'd tuned it into my
+own tool: standing instructions, a library of prompts for the jobs I ran most
+often, and conventions for how it wrote code, commits, and reviews. I asked, it
+answered, and the work moved fast. Some months ran to the better part of a
+hundred commits, and that one
 project took most of them. The chat sat in a panel next to the code, in the
 editor, on my desk.
 

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -15,16 +15,17 @@ fast. Some months ran to the better part of a hundred commits, and that one
 project took most of them. The chat sat in a panel next to the code, in the
 editor, on my desk.
 
-By the time I was building this way, GitHub billed Copilot by the premium
-request. Each plan came with a set number every month, and past that they
-charged for each one. The models I leaned on burned through that number, so the
-real limit was the budget I set for myself. I was glad to pay it. At my pace
-even that ran tight, and by the spring it wasn't enough.
+Then, in April, GitHub [changed its individual Copilot plans][copilot-plans].
+Even on the top tier, none of the Claude models were included any more; every
+token I spent on them came out of my own budget. And Claude was the only model I
+reached for. Paying GitHub for a plan that no longer covered the one model I used
+stopped making sense. If I was buying those tokens anyway, I could buy them from
+the people who made the model.
 
-In April I was at GrafanaCON in Barcelona, and I tried the Claude subscription.
-I was on the Claude models anyway, so it was a small thing to try. A flat rate
-put the per-token charge out of my life, and that relief was all I'd come for. I
-expected a cheaper version of what I already had, and little more.
+That same week I was at GrafanaCON in Barcelona, and I tried the Claude
+subscription. It was the model I already used, so it was a small thing to try. On
+the subscription it came at one flat price a month, and that relief was all I'd
+come for. I expected a cheaper version of what I already had, and little more.
 
 Then I flew home. On the plane, over the wifi, I opened the chats on my phone
 and planned projects. I wasn't writing code, only thinking through what to build
@@ -49,3 +50,17 @@ your hand](/posts/i-built-the-machine-twice); this time the tool helped shape
 itself. Claude built most of that scaffolding with me, and each piece made the
 next thing quicker to start. You can watch it go up in the history, a few days
 after I got home.
+
+The talk now is all about the cost: what these tools run, who can afford to keep
+them going, where the spending stops. A bill came due for me too, only not in
+dollars. Starting something costs next to nothing now. I can open a chat from a
+queue or a train and have a project underway before I reach the front. I don't
+lose track of them; I come back, look, and pull things along. That keeps me at
+the edge of what I can carry, and never quite past it.
+
+The edge is just where I live now. The meter I ran from was measured in money,
+and I got out from under it. The one that replaced it is measured in me. I set
+out to spend less effort, and instead the work grew until it filled everything I
+had to give.
+
+[copilot-plans]: https://github.blog/news-insights/company-news/changes-to-github-copilot-individual-plans/

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -25,3 +25,13 @@ In April I was at GrafanaCON in Barcelona, and I tried the Claude subscription.
 I was on the Claude models anyway, so it was a small thing to try. A flat rate
 put the per-token charge out of my life, and that relief was all I'd come for. I
 expected a cheaper version of what I already had, and little more.
+
+Then I flew home. On the plane, over the wifi, I opened the chats on my phone
+and planned projects. I wasn't writing code, only thinking through what to build
+and how. I had never done that away from my desk. Copilot had lived in the
+editor, so my work had lived there too.
+
+It took a few minutes to see that I hadn't bought a cheaper Copilot. I'd bought
+a different way to work. From a seat on a plane I could hand Claude Code a task
+and drive it by remote, with nothing in front of me but a phone. The work had
+left the desk.

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -35,3 +35,17 @@ It took a few minutes to see that I hadn't bought a cheaper Copilot. I'd bought
 a different way to work. From a seat on a plane I could hand Claude Code a task
 and drive it by remote, with nothing in front of me but a phone. The work had
 left the desk.
+
+What changed after that wasn't how much I got done. It was how many things I
+could keep moving at once. Under Copilot, one project had taken most of what I
+had. Now the work spread out. Projects I'd left for dead started moving again.
+This blog was one of them, quiet since 2020 and now taking over a hundred
+commits in a month.
+
+The cost of the change was real, but it wasn't money. It was the tooling. I
+rebuilt the way I worked around Claude: the instructions, the skills, the small
+configurations. I've written before about [shaping a generic tool until it fits
+your hand](/posts/i-built-the-machine-twice); this time the tool helped shape
+itself. Claude built most of that scaffolding with me, and each piece made the
+next thing quicker to start. You can watch it go up in the history, a few days
+after I got home.


### PR DESCRIPTION
## Summary

Adds "Off the Desk" (closes #232): leaving GitHub Copilot for Claude after the April 2026 individual-plans change dropped the one model I used from what my plan covered, then finding the switch wasn't a cheaper tool but a different medium — the work off the desk, run from a phone, and the real limit my own capacity rather than money. Publication is gated by a future `pubDatetime` (2026-07-26, 08:00 BST), not a draft flag.

## Verification

- `pnpm build` clean — `astro check` + build + pagefind.
- Vale (incl. the Flesch reading-ease gate) + markdownlint pass.
- Forcing function cited to GitHub's 2026-04-20 individual-plans change; GrafanaCON dates and the commit-history anchors are provable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBzgM2H9pTnRXWRLcJyMZ7
