### PR TITLE
Resolve pubDatetime collision and document scheduling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,15 @@ future date keeps the post hidden via AstroPaper's
 `SITE.scheduledPostMargin`. **Never** set `draft: true` — merging the
 PR accepts the editorial work, the future date defers publication.
 
+### Scheduling
+
+`pubDatetime` is 08:00 local — `Europe/London` currently; override the
+per-post `timezone:` for archival posts authored in another zone. The
+weekday carries content type: Tuesday for tech / methodology, Sunday
+for personal / reflective (skip Monday and Friday). No two posts share
+a `pubDatetime`. When a date collides or a post slips its slot, move it
+to the next open date on its own weekday — not the next calendar day.
+
 ### "How I X" series
 
 Future entries title as `How I X (YYYY)` — year-stamped scales without

--- a/src/data/blog/off-the-desk.md
+++ b/src/data/blog/off-the-desk.md
@@ -1,5 +1,5 @@
 ---
-pubDatetime: 2026-07-26T07:00:00Z
+pubDatetime: 2026-08-09T07:00:00Z
 title: Off the Desk
 description: "GitHub dropped my one model from Copilot. I went to Claude, and the work came off the desk onto my phone."
 tags:


### PR DESCRIPTION
## Summary

`off-the-desk` and `under-the-instruments` were both scheduled for `2026-07-26T07:00:00Z`; two posts can't share a publish moment. `off-the-desk` now publishes `2026-08-09`, the next open Sunday slot (keeping its content-type weekday), and the scheduling convention it violated — 08:00 local, weekday-by-content-type, no shared `pubDatetime` — is now written into `CLAUDE.md`, which was previously silent on it.

Both posts are future-dated, so this only reshuffles the scheduled queue; nothing published changes.

## Verification

- Swept every post's `pubDatetime`: `2026-07-26` was the only collision, and `2026-08-09` is otherwise free and a Sunday.

Follow-up #369 tracks automating this as a pre-commit/CI check.