### PR TITLE
Consolidate writing conventions to single sources

### DIFF
--- a/.claude/citations.md
+++ b/.claude/citations.md
@@ -1,31 +1,28 @@
 # Citations
 
-How to ground a post's claims in the author's actual reading. Shared by
-`post-draft` and `review-draft`; agent-facing (MCP tool calls a human
-never makes).
+Standards for grounding a post's claims in the author's actual reading.
+Shared by `post-draft` and `review-draft`.
 
-Ground claims where applicable — don't fabricate citations to works the
-author hasn't engaged with. If the archive lacks a canonical source for a
-claim, surface what's actually there honestly rather than inventing one.
+## Standards
 
-## Find the reading
+- **Ground claims in reading the author actually engaged with.** Don't
+  fabricate citations to works they haven't read. If the archive holds no
+  canonical source for a claim, surface what's there honestly rather than
+  inventing one.
+- **Cite the original public source URL.** Never link the private
+  `https://read.readwise.io/...` URLs — readers can't reach them.
+- **Long URLs use reference-style links,** to stay within the 80-char
+  source wrap.
+
+## Finding the source (Readwise / Reader MCP)
+
+The author's reading lives in Readwise and Reader; reach it via MCP:
 
 - `mcp__claude_ai_Readwise__readwise_search_highlights` — vector-search
   the claim's topic. Add `full_text_queries` alongside the required
   `vector_search_term` for better recall.
 - `mcp__claude_ai_Readwise__reader_search_documents` — filter
   `location_in=["archive"]`, vector-search the topic.
-
-## Get a public URL
-
-Resolve the original source URL via
-`mcp__claude_ai_Readwise__reader_list_documents` with
-`response_fields=["url", "source_url", "title", "source"]`.
-
-**Never link the private `https://read.readwise.io/...` URLs** — readers
-can't reach them. Cite the original source URL only.
-
-## Link style
-
-For long URLs, use reference-style links to stay within the 80-char
-source wrap.
+- `mcp__claude_ai_Readwise__reader_list_documents` with
+  `response_fields=["url", "source_url", "title", "source"]` — resolve the
+  public source URL to cite (not the private Reader URL).

--- a/.claude/citations.md
+++ b/.claude/citations.md
@@ -1,0 +1,31 @@
+# Citations
+
+How to ground a post's claims in the author's actual reading. Shared by
+`post-draft` and `review-draft`; agent-facing (MCP tool calls a human
+never makes).
+
+Ground claims where applicable — don't fabricate citations to works the
+author hasn't engaged with. If the archive lacks a canonical source for a
+claim, surface what's actually there honestly rather than inventing one.
+
+## Find the reading
+
+- `mcp__claude_ai_Readwise__readwise_search_highlights` — vector-search
+  the claim's topic. Add `full_text_queries` alongside the required
+  `vector_search_term` for better recall.
+- `mcp__claude_ai_Readwise__reader_search_documents` — filter
+  `location_in=["archive"]`, vector-search the topic.
+
+## Get a public URL
+
+Resolve the original source URL via
+`mcp__claude_ai_Readwise__reader_list_documents` with
+`response_fields=["url", "source_url", "title", "source"]`.
+
+**Never link the private `https://read.readwise.io/...` URLs** — readers
+can't reach them. Cite the original source URL only.
+
+## Link style
+
+For long URLs, use reference-style links to stay within the 80-char
+source wrap.

--- a/.claude/skills/outline-draft/SKILL.md
+++ b/.claude/skills/outline-draft/SKILL.md
@@ -11,6 +11,8 @@ that outline and refuses to start without it.
 
 Stories only. Technical posts outline by their subject, not by scene.
 
+Pipeline: **substance → outline → diagnose → approval.**
+
 ## Why this is its own step
 
 The outline-approval gate is the most important control point in the
@@ -136,6 +138,11 @@ opposite), the surrounding years as context, open questions to confirm.>
 
 - <unresolved thread: a citation to find, a fact to confirm>
 ```
+
+## When to invoke
+
+- `/outline-draft #N` — build the outline for an idea issue's story.
+- `/outline-draft` — freeform story, no issue.
 
 ## Output
 

--- a/.claude/skills/post-draft/SKILL.md
+++ b/.claude/skills/post-draft/SKILL.md
@@ -14,8 +14,9 @@ The outline is the source of truth and is never edited from here. If the
 prose needs a structural change, change the outline first (via
 `outline-draft`), then bring the post back in line.
 
-Pipeline: **body → voice → citations → frontmatter.** Each stage has
-different ownership; don't conflate them.
+Pipeline: **body → conventions → syndication check.** The body is the
+story-specific craft this skill owns; the conventions are shared and
+applied from their single homes.
 
 ## 1. Body — write the scenes
 
@@ -77,129 +78,27 @@ wording together, lock it, move to the next. Flow and direction shift as
 the prose takes form; watch the back half, where unattended stretches
 drift toward generic prose.
 
-## 2. Voice
+## 2. Conventions
 
-Sentence-level conventions, applied across the drafted body. Stated in
-full here so the skill stands alone on the web, where local memory isn't
-present; the bracketed names are local-only see-alsos.
+Voice, citations, and frontmatter are shared across every article type.
+Apply them from their single homes — don't restate them here:
 
-These are the *prescriptive* rules. `.claude/voice.md` is the
-*descriptive* fingerprint measured from the published corpus (hedging
-cadence, formatting density, the honest-limitation closer, the
-narrative-vs-methodology registers) — read it alongside this section to
-calibrate against what the blog actually does.
+- **Voice** → `.claude/voice.md`. Sentence-level rules and the
+  poetic-without-poetry register; apply across the drafted body, then run
+  its revision pass. The descriptive fingerprint in the same file
+  calibrates against what the corpus measurably does.
+- **Citations** → `.claude/citations.md`. Ground claims in the author's
+  actual reading; never link private Reader URLs.
+- **Frontmatter and scheduling** → `docs/reference/post-frontmatter.md`.
+  Fields, the Tuesday (tech) / Sunday (reflective) cadence, timezone,
+  never `draft: true`, tags, archival stanza.
 
-- **No blame in retrospect.** Ownership ("I did X") is fine; regret ("I
-  should have", confession closers) goes. ([[feedback_no_blame_in_retrospect]])
-- **Causal over contrast.** "Without X, Y happens" beats "X required Z; Y
-  doesn't" — show the mechanism. ([[feedback_causal_narrative_over_contrast]])
-- **Tags are content topics,** not archive / era / format labels.
-  ([[feedback_tags_are_content_only]])
-- **Grammar leans CMOS, en_GB for spelling and quotes:** Oxford comma,
-  unspaced em-dashes, spelled-out numbers, semicolons; en_GB spelling and
-  punctuation outside the quotes. ([[project_grammar_lean]])
-- **Possessives:** singular *s*-ending nouns take *'s* — Books's,
-  Charles's (CMOS, not AP). ([[project_possessive_convention]])
-- **One independent clause per sentence.** Split every `, and`, semicolon,
-  or comma-splice that hooks two complete thoughts together. Length comes
-  from subordinate clauses (`which…`, `while…`, `that…`) and cadence, not
-  from chaining independents. Compound predicates on one subject are fine
-  ("he shows X and stops there"); this reinforces *flow, don't snap* below
-  — flow through subordination, never through a pile-up of independents.
+Story-specific: choose the title once the prose exists and the body has
+settled what it argues (anniversary / revision / substrate-shift /
+freeform); derive the description from the finished body. Draft both from
+the completed post, never front-load them.
 
-**Register — poetic without being poetry** (Tolkien/Carroll touchstone),
-the house voice for story posts:
-
-- **Latch first.** Open each scene on something concrete the reader can
-  hold — never on context-free abstraction.
-- **Flow, don't snap.** Carry weight in cadence and image, not in clipped
-  fragments stacked for drama.
-- **Punctuation marks structure, not pauses.** Let the period carry the
-  load. A comma only for a grammatical job (clause join, serial list,
-  trailing absolute), never a mid-clause interrupter for emphasis.
-  Colons, semicolons, and em-dashes earn their place only by doing real
-  structural work, not as dressing. A colon that tacks a list onto a weak
-  phrase ("Puzo's is rich: …") is a smell — rewrite so a verb carries it. A
-  plain serial list (a, b, and c) beats polysyndeton (a and b and c).
-- **Restrained metaphor.** Dial figures *ever so slightly* — a vivid
-  simile usually wants toning down, not up.
-- **Watch personification.** It creeps in ("a busy place", "a last sign
-  of life") — keep it light.
-- Plain, warm words: punch without the snap, music without verse.
-
-Pass:
-
-- Drop summary-as-flourish ("outlasted them all", "Everything between me
-  and the books").
-- Ease in via personal continuity ("I'm still…", "Since college I've
-  always…") rather than fragment-label openers.
-- Don't repeat temporal anchors; book-end them.
-- Em-dashes only for information asides, not drama.
-- No announced transitions: cut any sentence whose only job is to signal a
-  pivot ("There's more to it, though:", "I'll keep this above the plot");
-  state the next thing and let the paragraph break carry the turn.
-- No editorialising tail on a close that already lands ("…which is the truest
-  thing a book like this could leave me"), and no weak trailing cliffhanger
-  ("mostly that's all it is").
-- Active verbs over dead linking: an agent doing something beats "X is Y's",
-  and never force a verb onto an abstraction ("the mean that reaches").
-- Strip blame: no "I should have", no confession closers.
-- CMOS-style possessives; add new variants to
-  `.vale/styles/config/vocabularies/Custom/accept.txt` as
-  Custom.Spelling surfaces them.
-
-Iterate in the file; apply principles confidently, surface only genuine
-judgement calls.
-
-## 3. Citations
-
-Ground claims in the author's actual reading where applicable:
-
-- `mcp__claude_ai_Readwise__readwise_search_highlights` — vector-search
-  the claim's topic.
-- `mcp__claude_ai_Readwise__reader_search_documents` — filter
-  `location_in=["archive"]`, vector-search.
-
-Get **original source URLs** from
-`mcp__claude_ai_Readwise__reader_list_documents` with
-`response_fields=["url", "source_url", "title", "source"]`. Never use the
-private `https://read.readwise.io/...` URLs — readers can't reach them.
-
-For long URLs, use reference-style links to stay within the 80-char
-source wrap. If the archive lacks canonical citations, surface what's
-actually there honestly; don't fabricate citations to works the author
-hasn't engaged with.
-
-## 4. Frontmatter
-
-Apply codified conventions:
-
-- `pubDatetime`: 08:00 in the author's period-appropriate IANA timezone.
-  **Tuesday** for tech / methodology, **Sunday** for casual /
-  reflective. Skip Monday and Friday unless there's a reason. See
-  [[project_publication_time_convention]].
-- `timezone`: per-post override when the authoring zone differs from
-  `SITE.timezone`.
-- `description`: derived from the final body, ~120–150 chars. No stale
-  references to cut sections.
-- `tags`: 2–3 content topics, soft cap ~3. No categorical labels
-  (archive / era / format).
-- `title`: anniversary / revision / substrate-shift / freeform — pick
-  what the body argues.
-- **Never** set `draft: true`. Publication is gated by a future
-  `pubDatetime` and `SITE.scheduledPostMargin`; merging the PR accepts
-  the work. See [[feedback_drafts_via_date_not_flag]].
-- `hideEditPost: true` for archival republishes or immutable content.
-- Archival republishes live under `src/data/blog/_<engine>/` and open
-  with the stock stanza ([[project_archive_stanza]]).
-
-**Don't pin** `pubDatetime` / `modDatetime` to local-branch commits —
-both are live-site moments ([[feedback_post_datetime_semantics]]). Use a
-future `pubDatetime` as both gate and placeholder; pick the *nearest*
-cadence-appropriate day, since `SITE.scheduledPostMargin` is ~15 minutes
-and the date is the real publish target.
-
-## 5. Instagram syndication check
+## 3. Instagram syndication check
 
 dlvr.it auto-syndicates each post to the text and link surfaces from the
 RSS feed (`docs/adr/0001-use-dlvrit-for-social-syndication.md`) — no

--- a/.claude/skills/review-draft/SKILL.md
+++ b/.claude/skills/review-draft/SKILL.md
@@ -23,9 +23,11 @@ character-limited networks (Bluesky, Threads) regardless. A note-length
 artefact and belongs to `note-draft` (#323) and the note pipeline (#321/#322),
 not here.
 
-Voice, citations, frontmatter, and Instagram
-syndication are shared — apply `post-draft` §2–5 and `.claude/voice.md` for
-those; only the review-specific deltas live here.
+Voice, citations, frontmatter, and the Instagram check are shared. Apply
+them from their single homes — voice (`.claude/voice.md`), citations
+(`.claude/citations.md`), frontmatter and scheduling
+(`docs/reference/post-frontmatter.md`); only the review-specific deltas
+live here.
 
 Pipeline: **gate → substance → spine (approval) → draft → frontmatter.**
 
@@ -125,7 +127,7 @@ originate here and flow forward, never back-ported from the draft
 ## 4. Draft — argument, not summary
 
 Render the spine into `src/data/blog/reviews/<slug>.md`, one point at a time with the
-author. Review-specific rules, on top of `post-draft` §2 voice:
+author. Review-specific rules, on top of the blog voice (`.claude/voice.md`):
 
 - **Argument outweighs summary, roughly four to one.** Every evaluative claim
   carries a specific moment from the work as its evidence. A paragraph that
@@ -176,11 +178,13 @@ author. Review-specific rules, on top of `post-draft` §2 voice:
   in the body as thematic analysis; the description can't carry them.
 - Otherwise the blog voice holds: first person, hedged, headerless reflective
   register, CMOS grammar, very low formatting — prose carries the structure
-  (`post-draft` §2, `.claude/voice.md`).
+  (`.claude/voice.md`).
 
 ## 5. Frontmatter, citations, syndication
 
-`post-draft` §3–5 apply unchanged, with review-specific notes:
+The shared conventions apply unchanged — citations (`.claude/citations.md`),
+frontmatter and scheduling (`docs/reference/post-frontmatter.md`), and the
+Instagram check — with review-specific notes:
 
 - **Location and cover:** reviews live in `src/data/blog/reviews/<slug>.md`,
   which serves at `/posts/reviews/<slug>/` (the theme keeps non-`_` folders in
@@ -190,15 +194,17 @@ author. Review-specific rules, on top of `post-draft` §2 voice:
   `ogImage: ../../../assets/images/<slug>-cover.jpg` (three `../` from the
   deeper `reviews/` folder). It replaces the dynamic OG card.
 - **Cadence:** reviews are reflective — **Sunday** 08:00 local for `pubDatetime`
-  ([[project_publication_time_convention]]).
+  (`docs/reference/post-frontmatter.md`).
 - **Tags are the work's subject, not the format.** Tag what the review is
   *about* — the mafia, myth-making, whatever the argument engages — never
   `review` or `book`; those are format/era labels the taxonomy forbids
-  ([[feedback_tags_are_content_only]]).
+  (`docs/reference/post-frontmatter.md`).
 - **Instagram:** reviews are strongly image-prone (covers, screenshots, box
-  art). Flag `/syndicate-instagram <slug>` once live (`post-draft` §5).
+  art). dlvr.it covers the auto surfaces on publish
+  (`docs/adr/0001-use-dlvrit-for-social-syndication.md`); flag
+  `/syndicate-instagram <slug>` once live.
 - **Never** `draft: true`; a future `pubDatetime` gates publication
-  ([[feedback_drafts_via_date_not_flag]]).
+  (`docs/reference/post-frontmatter.md`).
 
 ## When to invoke
 

--- a/.claude/skills/syndicate-instagram/SKILL.md
+++ b/.claude/skills/syndicate-instagram/SKILL.md
@@ -18,6 +18,8 @@ nothing is committed.
 Invoke: `/syndicate-instagram [path|slug|url]` — defaults to the newest post
 under `src/data/blog/`.
 
+Pipeline: **resolve → extract kernel → draft → present.**
+
 ## 1. Resolve the post
 
 Accept a file path, slug, or live URL. Default: the newest post by

--- a/.claude/voice.md
+++ b/.claude/voice.md
@@ -1,20 +1,96 @@
 # Blog voice
 
-Descriptive fingerprint of this blog's published voice, calibrated
-against the author-written posts in `src/data/blog/` (not the AstroPaper
-upstream tutorial posts). Use it when Claude drafts or edits any post —
-story, methodology, or freeform.
+The blog's voice home. Two halves, kept distinct but co-located:
 
-Two companions, kept distinct:
+- **Prescriptive rules** (below) — the sentence-level conventions and
+  story register to *apply* when drafting or editing a post.
+- **Descriptive fingerprint** (further down) — what the published posts
+  measurably *do*, calibrated from the corpus. When the two overlap they
+  agree; when in doubt, the corpus is the evidence.
 
-- `post-draft/SKILL.md` §2 is the *prescriptive* story register — rules
-  to apply (CMOS grammar, latch-first, no blame in retrospect). This
-  file is the *descriptive* corpus fingerprint — what the published
-  posts measurably do. When they overlap they agree; when in doubt,
-  the corpus here is the evidence.
+Read this before drafting or editing any post — story, review,
+methodology, or freeform. `post-draft` and `review-draft` apply it; they
+don't restate it.
+
+Companions, kept separate:
+
 - The host `~/.claude/voice.md` profiles the author's *external* voice
   (PR/issue comments, calibrated against pre-2025 GitHub). Different
   corpus, different surface — don't apply it to blog posts.
+- Frontmatter, scheduling, tags, and locations live in
+  `docs/reference/post-frontmatter.md`, not here.
+
+Stated in full so the skills stand alone on the web, where host memory
+isn't present; bracketed `[[names]]` are local-only see-alsos.
+
+## Sentence-level rules
+
+- **No blame in retrospect.** Ownership ("I did X") is fine; regret ("I
+  should have", confession closers) goes.
+  ([[feedback_no_blame_in_retrospect]])
+- **Causal over contrast.** "Without X, Y happens" beats "X required Z; Y
+  doesn't" — show the mechanism. ([[feedback_causal_narrative_over_contrast]])
+- **Grammar leans CMOS, en_GB for spelling and quotes:** Oxford comma,
+  unspaced em-dashes, spelled-out numbers, semicolons; en_GB spelling and
+  punctuation outside the quotes. ([[project_grammar_lean]])
+- **Possessives:** singular *s*-ending nouns take *'s* — Books's,
+  Charles's (CMOS, not AP). Add new variants to
+  `.vale/styles/config/vocabularies/Custom/accept.txt` as Custom.Spelling
+  surfaces them. ([[project_possessive_convention]])
+- **One independent clause per sentence.** Split every `, and`, semicolon,
+  or comma-splice that hooks two complete thoughts together. Length comes
+  from subordinate clauses (`which…`, `while…`, `that…`) and cadence, not
+  from chaining independents. Compound predicates on one subject are fine
+  ("he shows X and stops there"); this reinforces *flow, don't snap* below
+  — flow through subordination, never through a pile-up of independents.
+
+## Register: poetic without being poetry
+
+The house register for story posts (Tolkien/Carroll touchstone):
+
+- **Latch first.** Open each scene on something concrete the reader can
+  hold — never on context-free abstraction.
+- **Flow, don't snap.** Carry weight in cadence and image, not in clipped
+  fragments stacked for drama.
+- **Punctuation marks structure, not pauses.** Let the period carry the
+  load. A comma only for a grammatical job (clause join, serial list,
+  trailing absolute), never a mid-clause interrupter for emphasis.
+  Colons, semicolons, and em-dashes earn their place only by doing real
+  structural work, not as dressing. A colon that tacks a list onto a weak
+  phrase ("Puzo's is rich: …") is a smell — rewrite so a verb carries it. A
+  plain serial list (a, b, and c) beats polysyndeton (a and b and c).
+- **Restrained metaphor.** Dial figures *ever so slightly* — a vivid
+  simile usually wants toning down, not up.
+- **Watch personification.** It creeps in ("a busy place", "a last sign
+  of life") — keep it light.
+- Plain, warm words: punch without the snap, music without verse.
+
+## Revision pass
+
+- Drop summary-as-flourish ("outlasted them all", "Everything between me
+  and the books").
+- Ease in via personal continuity ("I'm still…", "Since college I've
+  always…") rather than fragment-label openers.
+- Don't repeat temporal anchors; book-end them.
+- Em-dashes only for information asides, not drama.
+- No announced transitions: cut any sentence whose only job is to signal a
+  pivot ("There's more to it, though:", "I'll keep this above the plot");
+  state the next thing and let the paragraph break carry the turn.
+- No editorialising tail on a close that already lands ("…which is the truest
+  thing a book like this could leave me"), and no weak trailing cliffhanger
+  ("mostly that's all it is").
+- Active verbs over dead linking: an agent doing something beats "X is Y's",
+  and never force a verb onto an abstraction ("the mean that reaches").
+- Strip blame: no "I should have", no confession closers.
+
+Iterate in the file; apply the rules confidently, surface only genuine
+judgement calls.
+
+---
+
+The rest of this file is the **descriptive fingerprint** — measured from
+the corpus, not rules to apply. Recalibrate by re-reading the posts, not
+by editing numbers here from memory.
 
 ## Corpus
 
@@ -22,8 +98,7 @@ Four current author posts as of 2026-07: `how-i-back-up`,
 `how-i-read-eight-years-on` (methodology); `i-built-the-machine-twice`,
 `the-bottleneck-isnt-the-blank-page` (narrative). The archival
 restorations under `_hakyll/` are an older, lightly-copyedited era —
-weak calibration; weight the four current posts. Recalibrate by
-re-reading the corpus, not by editing numbers here from memory.
+weak calibration; weight the four current posts.
 
 ## Shared DNA — every post
 
@@ -71,8 +146,7 @@ re-reading the corpus, not by editing numbers here from memory.
 - Second person to pull the reader in, sparingly ("You picture the blank
   page"). Narrative-only; the methodology posts stay first-person.
 - Restrained figuration — a governing image ("the machine", "the wall")
-  worked lightly, never purple. See `post-draft/SKILL.md` §2 for the
-  full "poetic without being poetry" register.
+  worked lightly, never purple. See the poetic register above.
 - Scene and contrast: opens at the opposite of where it lands.
 
 ## Register: methodology / reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ scripting your own.
   file types (no checker): binary assets (svg/png/webp), `lychee.toml`,
   `.vale.ini`. lychee link-checking is CI-only
   (`.github/workflows/lychee.yml`, `lychee.toml`).
-- Custom skills under `.claude/skills/`: digest, tag-suggest,
-  outline-draft, post-draft, review-draft, syndicate-instagram
-  (detailed below).
+- Custom skills under `.claude/skills/` — catalogued in the Skills
+  section below; each SKILL.md frontmatter is the authoritative
+  description.
 
 ## Scope discipline
 
@@ -57,23 +57,13 @@ so the repo-relevant essentials:
 ## Posting convention
 
 New posts live under `src/data/blog/`; archival republishes under
-`src/data/blog/_<engine>/`. Reviews live under `src/data/blog/reviews/`
-(a `/posts/reviews/<slug>/` URL — the theme keeps non-`_` folders in the
-path) and carry the reviewed work's cover as `ogImage`, the one post type
-that does; the cover file goes in `src/assets/images/<slug>-cover.jpg`.
-Publication is gated by `pubDatetime`: a future date keeps the post
-hidden via AstroPaper's `SITE.scheduledPostMargin`. **Never** set
-`draft: true` — merging the PR accepts the editorial work, the future
-date defers publication.
+`src/data/blog/_<engine>/`; reviews under `src/data/blog/reviews/`.
+Publication is gated by a future `pubDatetime`, never `draft: true` —
+merging the PR accepts the editorial work, the date defers publication.
 
-### Scheduling
-
-`pubDatetime` is 08:00 local — `Europe/London` currently; override the
-per-post `timezone:` for archival posts authored in another zone. The
-weekday carries content type: Tuesday for tech / methodology, Sunday
-for personal / reflective (skip Monday and Friday). No two posts share
-a `pubDatetime`. When a date collides or a post slips its slot, move it
-to the next open date on its own weekday — not the next calendar day.
+Frontmatter fields, the Tuesday (tech) / Sunday (reflective) 08:00
+cadence, timezone, locations, cover images, and tags are documented in
+`docs/reference/post-frontmatter.md`.
 
 ### "How I X" series
 
@@ -86,13 +76,11 @@ infrastructure (index page, schema field, milestone) until there are
 
 ## Voice
 
-`.claude/voice.md` is the descriptive fingerprint of the blog's
-published voice, calibrated against the author-written posts in
-`src/data/blog/`. Read it before drafting or editing any post — story,
-methodology, or freeform. It complements `post-draft/SKILL.md` §2 (the
-prescriptive story register) and is distinct from the host
-`~/.claude/voice.md`, which profiles the author's external PR/issue
-voice against a different corpus.
+`.claude/voice.md` is the blog's voice home — the prescriptive rules to
+apply and the descriptive fingerprint measured from the corpus. Read it
+before drafting or editing any post. Distinct from the host
+`~/.claude/voice.md`, which profiles the author's external PR/issue voice
+against a different corpus.
 
 ## AstroPaper upstream
 
@@ -118,50 +106,31 @@ Customized and free to edit: `src/config.ts`, `src/constants.ts`,
 - Default branch: `main`. PRs target `main`.
 - Deploy runs on push to `main` (`.github/workflows/pages.yml`).
 
-## Digest skill
+## Skills
 
-`.claude/skills/digest/` clusters a window of GitHub activity, Readwise
-highlights, and Reader archives into themes that might seed posts. It
-also runs an interactive Notion Media Log check-in: it asks what you're
-currently reading/playing, infers completions from whatever dropped off
-the active list, and writes the status changes back — surfacing each
-completion as a review kernel. Invoke via
-`/digest [Nd|Nw|Nm|Ny]` (defaults to `7d`). Promising kernels file as
-issues with the `idea` template.
+Custom skills under `.claude/skills/`; each SKILL.md frontmatter is the
+authoritative description. The writing pipeline:
 
-## Tag-suggest skill
+- `outline-draft` → `post-draft` — story posts: a scene-and-beat outline
+  gated at approval, then prose. `/outline-draft [#N]`, `/post-draft <slug>`.
+- `review-draft` — book/paper/game reviews (a claim and its evidence, not
+  a scene arc), a sibling of the story pipeline.
+  `/review-draft [#N|title|path]`.
 
-`.claude/skills/tag-suggest/` proposes frontmatter tags for a draft
-post — scans the corpus's existing tag inventory, prioritises reuse
-over invention, flags morphological near-duplicates. Invoke via
-`/tag-suggest <path>` (defaults to the currently staged post).
-Proposes first, then applies to the file only after the author
-confirms.
+Utilities:
 
-## Review-draft skill
+- `digest` — cluster a window of GitHub, Readwise, and Reader activity,
+  plus a Notion Media Log check-in, into post kernels.
+  `/digest [Nd|Nw|Nm|Ny]` (default `7d`).
+- `tag-suggest` — propose frontmatter tags for a draft; applies only
+  after confirmation. `/tag-suggest <path>`.
+- `syndicate-instagram` — hand-crafted Instagram post from a published
+  post (the one surface not auto-syndicated by dlvr.it).
+  `/syndicate-instagram [path|slug|url]`.
 
-`.claude/skills/review-draft/` drafts a review post — book, paper, or
-video game — from the one question a review answers: recommend it or
-not, and why. It gates first on whether there's a real argument (the
-"it was fine, nothing to see here" answer is a no-go, not a review),
-then lands the thesis, confirms a spine in `outlines/<slug>.md`, and
-builds argument-not-summary prose in the blog voice. A sibling of the
-story pipeline (`outline-draft` → `post-draft`), not a caller: reviews
-are a style of article, so they carry a claim and its evidence, not a
-scene arc. Voice, citations, and frontmatter reuse `post-draft` §2–5.
-Invoke via `/review-draft [#N|title|path]`.
-
-## Syndicate-Instagram skill
-
-`.claude/skills/syndicate-instagram/` crafts an Instagram post from a
-published post — caption hook, image or carousel guidance, link-in-bio
-handling, hashtag set. Instagram is the hand-crafted exception: Bluesky,
-Threads, Facebook, and LinkedIn auto-syndicate through dlvr.it (ADR
-0001), but Instagram is image-first and link-hostile, so the uniform
-feed hook fits worst there. Generation is automated; posting stays
-manual (draft in chat, nothing committed). Invoke via
-`/syndicate-instagram [path|slug|url]` (defaults to the most recently
-published post). Covers issue #79.
+Shared conventions the writing skills draw from: `.claude/voice.md`
+(voice), `.claude/citations.md` (citations), and
+`docs/reference/post-frontmatter.md` (frontmatter, scheduling, tags).
 
 ## Idea issues
 

--- a/docs/reference/post-frontmatter.md
+++ b/docs/reference/post-frontmatter.md
@@ -1,0 +1,100 @@
+# Post frontmatter and scheduling
+
+Reference for the frontmatter fields, scheduling rules, and file
+locations of a blog post. The schema lives in
+`src/content.config.ts`; this page documents the fields and the
+conventions layered on top of them.
+
+## Fields
+
+Each post opens with a YAML frontmatter block. Fields, in schema order:
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `author` | no | string | Defaults to `SITE.author`; set only to override. |
+| `pubDatetime` | yes | date | Publication moment. Gates visibility (see [Scheduling](#scheduling)). |
+| `modDatetime` | no | date \| null | Last substantive edit. A live-site moment, not a branch commit. |
+| `title` | yes | string | Post title. |
+| `featured` | no | boolean | Pins the post to the home page's featured list. |
+| `draft` | no | boolean | **Never set.** A future date gates publication, not this flag (see [Scheduling](#scheduling)). |
+| `tags` | no | string[] | Content topics; defaults to `["others"]`. See [Tags](#tags). |
+| `ogImage` | no | image \| string | Overrides the dynamic OG card. Set for reviews (see [Locations](#locations-and-urls)). |
+| `description` | yes | string | ~120–150 chars. Becomes `og:description` and the dlvr.it syndication text; state the thesis plainly. |
+| `canonicalURL` | no | string | Points elsewhere when the post is canonical off-site. |
+| `hideEditPost` | no | boolean | Hides the "edit this page" link. Set for archival or immutable content. |
+| `timezone` | no | string | IANA zone for interpreting `pubDatetime`/`modDatetime`; defaults to `SITE.timezone`. |
+
+`pubDatetime` and `modDatetime` are live-site moments. Don't pin them to
+a local-branch commit time; a future `pubDatetime` doubles as the
+publication gate and a placeholder.
+
+## Scheduling
+
+`pubDatetime` is **08:00 local**, where "local" is the post's
+`timezone` (`Europe/London` currently, so 08:00 British Summer Time
+serialises as `07:00:00Z`). The weekday carries content type:
+
+- **Tuesday**—tech / methodology.
+- **Sunday**—personal / reflective (reviews included).
+- Skip Monday and Friday unless there's a specific reason.
+
+No two posts share a `pubDatetime`. When a date collides or a post slips
+its slot, move it to the next open date **on its own weekday**—not the
+next calendar day.
+
+A future `pubDatetime` gates publication entirely: it keeps the post
+hidden via AstroPaper's `SITE.scheduledPostMargin` (~15 minutes), so the
+date is the real publish target. Merging a post's PR accepts the
+editorial work; the future date defers publication. Nothing sets
+`draft: true`.
+
+## Locations and URLs
+
+The blog collection loads `**/[^_]*.md` under `src/data/blog`; the build
+skips files and directories prefixed with `_`.
+
+| Content | Path | Served at |
+| --- | --- | --- |
+| New post | `src/data/blog/<slug>.md` | `/posts/<slug>/` |
+| Review | `src/data/blog/reviews/<slug>.md` | `/posts/reviews/<slug>/` |
+| Archival republish | `src/data/blog/_<engine>/<slug>.md` | `/posts/<slug>/` |
+
+The theme keeps non-`_` folders (like `reviews/`) in the URL path and
+strips `_`-prefixed folders (`_hakyll/`, `_releases/`), so archival posts
+still serve at `/posts/<slug>/`.
+
+Reviews carry the reviewed work's cover as `ogImage`, the one post type
+that overrides the dynamic OG card. The cover file goes in
+`src/assets/images/<slug>-cover.jpg`, referenced with three `../` from
+the deeper `reviews/` folder:
+
+```yaml
+ogImage: ../../../assets/images/<slug>-cover.jpg
+```
+
+## Archival republishes
+
+Restored posts live under `src/data/blog/_<engine>/` (the engine of
+origin: `_hakyll/`, `_nikola/`). They set `hideEditPost: true`, carry a
+`timezone` matching the zone of authorship, and open with the stock
+stanza before the body:
+
+```markdown
+> **Archival republish.** From this blog's <engine> era; lightly copyedited.
+```
+
+`<engine>` matches the source directory ("Hakyll" for `_hakyll/`).
+
+## Tags
+
+Tags answer "what is this post *about*?"—content topics only. Archive,
+era, format, and draft-state signals live in directory structure or
+schema fields, never in tags. Soft cap of ~3; drop a marginal tag rather
+than padding.
+
+## Drafting artefacts
+
+Story and review drafts iterate in `outlines/<slug>.md` before the post
+exists. The `outlines/` directory is tracked but sits outside `src/`, so
+it stays unpublished and out of the prose linters and link checker. It's
+public in the repository.

--- a/docs/reference/post-frontmatter.md
+++ b/docs/reference/post-frontmatter.md
@@ -1,72 +1,72 @@
 # Post frontmatter and scheduling
 
-Reference for the frontmatter fields, scheduling rules, and file
-locations of a blog post. The schema lives in
-`src/content.config.ts`; this page documents the fields and the
-conventions layered on top of them.
+The frontmatter fields, scheduling rules, and file locations of a blog
+post. The schema is `src/content.config.ts`; this page adds the
+conventions layered on it.
 
 ## Fields
 
-Each post opens with a YAML frontmatter block. Fields, in schema order:
+Fields, in schema order:
 
-| Field | Required | Type | Notes |
+| Field | Required | Type | Meaning |
 | --- | --- | --- | --- |
-| `author` | no | string | Defaults to `SITE.author`; set only to override. |
-| `pubDatetime` | yes | date | Publication moment. Gates visibility (see [Scheduling](#scheduling)). |
-| `modDatetime` | no | date \| null | Last substantive edit. A live-site moment, not a branch commit. |
+| `author` | no | string | Defaults to `SITE.author`. |
+| `pubDatetime` | yes | date | Publication moment; gates visibility (see [Scheduling](#scheduling)). |
+| `modDatetime` | no | date \| null | Last substantive edit. |
 | `title` | yes | string | Post title. |
 | `featured` | no | boolean | Pins the post to the home page's featured list. |
-| `draft` | no | boolean | **Never set.** A future date gates publication, not this flag (see [Scheduling](#scheduling)). |
-| `tags` | no | string[] | Content topics; defaults to `["others"]`. See [Tags](#tags). |
-| `ogImage` | no | image \| string | Overrides the dynamic OG card. Set for reviews (see [Locations](#locations-and-urls)). |
-| `description` | yes | string | ~120–150 chars. Becomes `og:description` and the dlvr.it syndication text; state the thesis plainly. |
-| `canonicalURL` | no | string | Points elsewhere when the post is canonical off-site. |
-| `hideEditPost` | no | boolean | Hides the "edit this page" link. Set for archival or immutable content. |
-| `timezone` | no | string | IANA zone for interpreting `pubDatetime`/`modDatetime`; defaults to `SITE.timezone`. |
+| `draft` | no | boolean | Unused; publication gates on `pubDatetime`, not this flag. |
+| `tags` | no | string[] | Content topics; defaults to `["others"]` (see [Tags](#tags)). |
+| `ogImage` | no | image \| string | Overrides the dynamic OG card; reviews set it (see [Locations](#locations)). |
+| `description` | yes | string | ~120–150 chars; becomes `og:description` and the dlvr.it syndication text. |
+| `canonicalURL` | no | string | The canonical URL when the post is canonical off-site. |
+| `hideEditPost` | no | boolean | Hides the "edit this page" link. |
+| `timezone` | no | string | IANA zone for `pubDatetime`/`modDatetime`; defaults to `SITE.timezone`. |
 
-`pubDatetime` and `modDatetime` are live-site moments. Don't pin them to
-a local-branch commit time; a future `pubDatetime` doubles as the
-publication gate and a placeholder.
+`pubDatetime` and `modDatetime` are live-site moments, independent of
+branch commit time.
 
 ## Scheduling
 
-`pubDatetime` is **08:00 local**, where "local" is the post's
-`timezone` (`Europe/London` currently, so 08:00 British Summer Time
-serialises as `07:00:00Z`). The weekday carries content type:
+`pubDatetime` is 08:00 in the post's `timezone` (`Europe/London`
+currently, so 08:00 British Summer Time is `07:00:00Z`). The weekday
+encodes content type:
 
-- **Tuesday**—tech / methodology.
-- **Sunday**—personal / reflective (reviews included).
-- Skip Monday and Friday unless there's a specific reason.
+| Weekday | Content |
+| --- | --- |
+| Tuesday | Tech / methodology |
+| Sunday | Personal / reflective, including reviews |
 
-No two posts share a `pubDatetime`. When a date collides or a post slips
-its slot, move it to the next open date **on its own weekday**—not the
-next calendar day.
+Monday and Friday are unused. Each `pubDatetime` is unique; a collision
+or a slipped slot moves to the next open date on the same weekday.
 
-A future `pubDatetime` gates publication entirely: it keeps the post
-hidden via AstroPaper's `SITE.scheduledPostMargin` (~15 minutes), so the
-date is the real publish target. Merging a post's PR accepts the
-editorial work; the future date defers publication. Nothing sets
-`draft: true`.
+A future `pubDatetime` gates publication: AstroPaper's
+`SITE.scheduledPostMargin` (~15 minutes) hides the post until the date
+passes. Publication is independent of the merge; the date is the trigger.
+No post sets `draft: true`.
 
-## Locations and URLs
+## Locations
 
-The blog collection loads `**/[^_]*.md` under `src/data/blog`; the build
-skips files and directories prefixed with `_`.
+The blog collection loads `**/[^_]*.md` under `src/data/blog`, skipping
+`_`-prefixed files and directories.
 
-| Content | Path | Served at |
+| Content | Path | URL |
 | --- | --- | --- |
-| New post | `src/data/blog/<slug>.md` | `/posts/<slug>/` |
+| Post | `src/data/blog/<slug>.md` | `/posts/<slug>/` |
 | Review | `src/data/blog/reviews/<slug>.md` | `/posts/reviews/<slug>/` |
 | Archival republish | `src/data/blog/_<engine>/<slug>.md` | `/posts/<slug>/` |
 
-The theme keeps non-`_` folders (like `reviews/`) in the URL path and
-strips `_`-prefixed folders (`_hakyll/`, `_releases/`), so archival posts
-still serve at `/posts/<slug>/`.
+Non-`_` folders (`reviews/`) stay in the URL; `_`-prefixed folders
+(`_hakyll/`, `_releases/`) are stripped, so archival posts serve at
+`/posts/<slug>/`.
 
-Reviews carry the reviewed work's cover as `ogImage`, the one post type
-that overrides the dynamic OG card. The cover file goes in
-`src/assets/images/<slug>-cover.jpg`, referenced with three `../` from
-the deeper `reviews/` folder:
+Draft outlines live in `outlines/<slug>.md`: tracked, outside `src/`,
+unpublished, and excluded from the linters. Public in the repository.
+
+Reviews set `ogImage` to the reviewed work's cover, the only post type
+that overrides the dynamic OG card. The file is
+`src/assets/images/<slug>-cover.jpg`, referenced from the deeper
+`reviews/` folder with three `../`:
 
 ```yaml
 ogImage: ../../../assets/images/<slug>-cover.jpg
@@ -74,27 +74,18 @@ ogImage: ../../../assets/images/<slug>-cover.jpg
 
 ## Archival republishes
 
-Restored posts live under `src/data/blog/_<engine>/` (the engine of
-origin: `_hakyll/`, `_nikola/`). They set `hideEditPost: true`, carry a
-`timezone` matching the zone of authorship, and open with the stock
-stanza before the body:
+Restored posts live under `src/data/blog/_<engine>/` (`_hakyll/`,
+`_nikola/`). They set `hideEditPost: true`, set `timezone` to the zone of
+original authorship, and open with the stanza:
 
 ```markdown
 > **Archival republish.** From this blog's <engine> era; lightly copyedited.
 ```
 
-`<engine>` matches the source directory ("Hakyll" for `_hakyll/`).
+`<engine>` names the source ("Hakyll" for `_hakyll/`).
 
 ## Tags
 
-Tags answer "what is this post *about*?"—content topics only. Archive,
-era, format, and draft-state signals live in directory structure or
-schema fields, never in tags. Soft cap of ~3; drop a marginal tag rather
-than padding.
-
-## Drafting artefacts
-
-Story and review drafts iterate in `outlines/<slug>.md` before the post
-exists. The `outlines/` directory is tracked but sits outside `src/`, so
-it stays unpublished and out of the prose linters and link checker. It's
-public in the repository.
+Tags name what a post is about—content topics. Archive, era, format,
+and draft-state belong to directory structure or schema fields, not tags.
+The soft cap is ~3.


### PR DESCRIPTION
## Summary

The writing skills each carried their own copies of the voice rules, citation procedure, and frontmatter conventions; review-draft reached into post-draft by section number, and CLAUDE.md duplicated the scheduling block. Each convention now has one home, routed by audience, and everything points there instead of restating it.

- `docs/reference/post-frontmatter.md` — human-facing reference (Diátaxis), prose-linted: frontmatter fields, scheduling, locations, tags.
- `.claude/voice.md` — the single voice home: prescriptive rules (moved out of post-draft §2) plus the descriptive corpus fingerprint.
- `.claude/citations.md` — citation standards (ground claims in real reading, cite the public source URL), with the Readwise/Reader lookup as the mechanism.

## Gotchas

- The load-bearing seam is audience: `docs/` is Vale-linted, `.claude/` and `CLAUDE.md` are excluded by design (AI-targeted). That's why the reference doc had to clear the prose rules and the skills didn't — worth a look at `.pre-commit-config.yaml`'s `upstream_md_exclude` to confirm the split is intended.
- `post-frontmatter.md` also got a Diátaxis register pass, so its diff is a rewrite, not a straight lift: advisory/how-to phrasings ("Never set", "Skip Monday") are stated as declarative facts, and a stray drafting-process section was cut.
- post-draft's diff is large (~150 lines) but it's §2–5 moving out, not being deleted; the story-craft §1 is untouched.
- Scope held to consolidation. The per-skill prose clarity pass and writing-quality linting for AI-targeted docs are deliberately out, tracked as #375 and #374. #89 (the Vale per-path split that seeded this) was closed as obsolete — one uniform voice, no split to build. The planned note/tech draft skills (#293/#294, #320–#323) plug into these same homes, the reason to extract now.

## Verification

- `pre-commit run --files` across all changed files: passed (Vale, ESLint, markdownlint, hygiene).
- Grepped for stale coupling: zero remaining `post-draft §N` cross-references, and every shared-home path a skill points at resolves.